### PR TITLE
feat(segment): add anonymous id sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "bootstrap": "npm install && lerna bootstrap",
+    "setup-examples": "node ./scripts/installer.js",
     "clean": "rimraf packages/*/dist",
     "reset": "npm run clean && lerna clean --yes",
     "test": "lerna run test",

--- a/packages/analytics-plugin-segment/src/browser.js
+++ b/packages/analytics-plugin-segment/src/browser.js
@@ -4,7 +4,9 @@ const config = {
   /* Your segment writeKey */
   writeKey: null,
   /* Disable anonymous MTU */
-  disableAnonymousTraffic: false
+  disableAnonymousTraffic: false,
+  /* Sync segment Anonymous id with `analytics` Anon id */
+  syncAnonymousId: false
 }
 
 /**
@@ -71,8 +73,9 @@ export default function segmentPlugin(pluginConfig = {}) {
       })
     },
     /* Sync id when ready */
-    ready: ({ instance }) => {
-      if (typeof analytics === 'undefined') return
+    ready: ({ instance, config }) => {
+      if (!config.syncAnonymousId || typeof analytics === 'undefined') return
+      console.log('do it')
       const segmentUser = analytics.user()
       if (segmentUser) {
         const segmentAnonId = segmentUser.anonymousId()

--- a/packages/analytics-plugin-segment/src/browser.js
+++ b/packages/analytics-plugin-segment/src/browser.js
@@ -70,18 +70,24 @@ export default function segmentPlugin(pluginConfig = {}) {
         instance.storage.removeItem(key, 'cookie')
       })
     },
+    /* Sync id when ready */
+    ready: ({ instance }) => {
+      if (typeof analytics === 'undefined') return
+      const segmentUser = analytics.user()
+      if (segmentUser) {
+        const segmentAnonId = segmentUser.anonymousId()
+        const analyticsAnonId = instance.user('anonymousId')
+        // If has segment anonymous ID && doesnt match analytics anon id, update
+        if (segmentAnonId && segmentAnonId !== analyticsAnonId) {
+          instance.setAnonymousId(segmentAnonId)
+        }
+      }
+    },
     /* Check if segment loaded */
     loaded: () => {
       return window.analytics && !!analytics.initialized
     }
   }
-}
-
-function isDisabled(instance, config) {
-  if (!instance.user('userId') && config.disableAnonymousTraffic) {
-    return true
-  }
-  return false
 }
 
 /* Load Segment analytics.js on page */

--- a/scripts/installer.js
+++ b/scripts/installer.js
@@ -1,0 +1,27 @@
+const path = require('path')
+const fs = require('fs')
+const globby = require('markdown-magic').globby
+const cp = require("child_process")
+
+function installDeps(functionDir, cb) {
+  cp.exec("npm i", { cwd: functionDir }, cb)
+}
+
+(async () => {
+  console.log('Installing example deps. This can take some time')
+  console.log('Alternatively, you can cd into your example of choice and run "npm install"')
+  console.log()
+  const findJSFiles = ['*/package.json', '!node_modules', '!**/node_modules']
+  const directory = path.join(__dirname, '..', 'examples')
+	const foldersWithDeps = await globby(findJSFiles, { cwd: directory })
+
+  const folders = foldersWithDeps.map(fnFolder => {
+    return fnFolder.substring(0, fnFolder.indexOf("package.json"))
+  }).map((folder) => {
+    console.log(`Installing ${folder} deps`)
+    installDeps(path.join(__dirname, '..', 'examples', folder), () => {
+      console.log(`${folder} dependencies installed`)
+    })
+  })
+
+})()


### PR DESCRIPTION
Fix for https://github.com/DavidWells/analytics/issues/11

@tommedema this will automatically sync the anon id from segment with analytics anon id.

I'm wondering if we want to make this an option (with the default being on)

Trying to work through different use cases in my head.

What do you think?