### PR TITLE
WIP - Add `methods` to let plugins enrich the base API

### DIFF
--- a/examples/demo/src/utils/analytics/example-2.js
+++ b/examples/demo/src/utils/analytics/example-2.js
@@ -11,15 +11,53 @@ const analytics = Analytics({
   plugins: [
     {
       name: 'hahahaa',
+      methods: {
+        thingNo(one, two, three) {
+          console.log('thing one')
+        },
+        xyz(one, two, three) {
+          console.log('thing xyz')
+        },
+      },
       track: () => {
         console.log('hi')
-      }
+      },
+      rad: () => {
+        console.log('RADDDD')
+      },
     },
     {
       NAMESPACE: 'hello',
       track: () => {
         console.log('hi')
-      }
+      },
+      methods: {
+        thing(one, two, three) {
+          const additionalArg = arguments[arguments.length - 1]
+          const { instance } = this
+          console.log('this', this)
+          console.log('additionalArg', additionalArg)
+          console.log('one', one)
+          console.log('two', two)
+          console.log('three', three)
+          console.log('instance', this.instance)
+          console.log('state', additionalArg.getState())
+          this.instance.dispatch('radStart')
+        },
+        otherThing: (one, ...args) => {
+          const additionalArg = args[args.length - 1]
+          console.log('additionalArg', additionalArg)
+          console.log('otherThing', one)
+          additionalArg.on('radStart', () => {
+            console.log('Do the silly thing')
+          })
+        },
+        hey: (one, ...args) => {
+          const instance = args[args.length - 1]
+          console.log('instance', instance)
+          console.log('this', this)
+        },
+      },
     },
     exampleProviderPlugin({
       settingOne: 'xyz'


### PR DESCRIPTION
This will allow for plugins to extend the base analytics instance.

When the `methods` key is provided by a plugin, those functions are exposed by the main analytics instance and are callable anywhere else in the app.

The methods exposed also have access to all the [core api](https://getanalytics.io/api/) via `this` inside the function. This avoids the need to rely on global variables.

How is works is described below

```js
import Analytics from 'analytics'

const pluginExample = {
  name: 'plugin-example',
  /* Functions to expose to analytics instance */
  methods: {
    thing(one, two, three) {
      // do custom whatever
      // this.instance is the instance of analytics 
      const state = this.instance.getState()
    },
    otherThing: (one, ...args) => {
      // Arrow functions break this.x context. The instance is instead injected as last arg
      const instance = args[args.length - 1]
      instance.track('myCustomThing')
    }
  }
}

/* initialize analytics and load plugins */
const analytics = Analytics({
  debug: true,
  app: 'cool-beans',
  plugins: [
    pluginExample,
  ]
})

/* Usage example */
analytics.methods.thing('one', 'two', 'three')
analytics.methods.otherThing('1')
```

Because `thing` and `otherThing` are `methods` exposed by the plugin, they are callable by the analytics instance
