### PR TITLE
fix: Type Error - Cannot read property 'match' of undefined

### DIFF
--- a/packages/analytics-plugin-google-tag-manager/src/browser.js
+++ b/packages/analytics-plugin-google-tag-manager/src/browser.js
@@ -85,7 +85,7 @@ function googleTagManager(pluginConfig = {}) {
 export default googleTagManager
 
 function scriptLoaded() {
-  const scripts = document.getElementsByTagName('script')
+  const scripts = document.querySelectorAll('script[src]')
   return !!Object.keys(scripts).filter((key) => {
     const { src } = scripts[key]
     return src.match(/googletagmanager\.com\/gtm\.js/)


### PR DESCRIPTION
`scriptLoaded` function contains loop of all `script` tags on a page, filtering them by `src` attr, which don't always exists (there might be inline `<script>...</script>` tags without `src` attr).
So `script.src.match` erupts type error "Cannot read property 'match' of undefined".
I suggest replace `getElementsByTagName('script')` with `querySelectorAll('script[src]')`, so we can be sure that `src` attr really exists.
Another possible solution is to write something like this `(src || '').match(...)`, so we always have string defined and method `match` on it.
What you say?