### PR TITLE
Add missing dependency for failing test

### DIFF
--- a/packages/analytics-plugin-fullstory/package.json
+++ b/packages/analytics-plugin-fullstory/package.json
@@ -65,7 +65,8 @@
   "devDependencies": {
     "@babel/core": "7.5.5",
     "@babel/preset-env": "7.5.5",
-    "@babel/runtime": "7.5.5"
+    "@babel/runtime": "7.5.5",
+    "@babel/register": "^7.5.5"
   },
   "dependencies": {
     "camelcase": "^5.3.1"


### PR DESCRIPTION
When running `npm test`, the test currently fails:

```bash
$ npm test

> lerna run test

lerna notice cli v3.21.0
lerna info versioning independent
lerna info Executing command in 3 packages: "npm run test"
lerna ERR! npm run test exited 1 in '@analytics/fullstory'
lerna ERR! npm run test stdout:

> @analytics/fullstory@0.2.3 test /analytics/packages/analytics-plugin-fullstory
> ava -v

lerna ERR! npm run test stderr:
Error: Could not resolve required module '@babel/register'
```

This commit adds the missing dependency.