### PR TITLE
Update react-hooks docs for accuracy

### DIFF
--- a/site/main/source/utils/react-hooks.md
+++ b/site/main/source/utils/react-hooks.md
@@ -151,7 +151,7 @@ Below is an example of using `withAnalytics`
 
 ```js
 import React, { Component } from 'react'
-import { useAnalytics } from 'use-analytics'
+import { withAnalytics } from 'use-analytics'
 
 class App extends Component {
   render() {


### PR DESCRIPTION
I believe we want to import `withAnalytics` here, not `useAnalytics`.