### PR TITLE
feat: initialize server side google analytics with multiple options

### DIFF
--- a/packages/analytics-plugin-google-analytics/src/node.js
+++ b/packages/analytics-plugin-google-analytics/src/node.js
@@ -7,12 +7,24 @@ if (!process.browser) {
 /**
  * Serverside Google Analytics plugin
  * @param {object} pluginConfig - Plugin settings
- * @param {string} pluginConfig.trackingId - Google Analytics site tracking Id
+ * @param {string} pluginConfig.trackingId - Google Analytics site tracking Id. Same as tid (se below), only one needed
+ * @param {string} pluginConfig.tid - Google Analytics site tracking Id. Same as trackingId (se above), only one needed
+ * @param {string} [pluginConfig.cid] - Google Analytics client Id. It generates a random UUID if none is set
+ * @param {boolean} [pluginConfig.strictCidFormat] - Set it to false to set a custom client Id (not UUID). Only used if cid is set
+ * @param {string} [pluginConfig.uid] - Google Analytics user Id
  * @return {*}
  * @example
  *
  * googleAnalytics({
- *   trackingId: '123-xyz'
+ *   trackingId: '123-xyz',
+ *   cid: '123456789.987654321',
+ *   strictCidFormat: false
+ * })
+ *
+ * googleAnalytics({
+ *   tid: '123-xyz',
+ *   cid: '123456789.987654321',
+ *   strictCidFormat: false
  * })
  */
 function googleAnalytics(pluginConfig = {}) {
@@ -48,8 +60,9 @@ function googleAnalytics(pluginConfig = {}) {
 export default googleAnalytics
 
 export function initialize(config) {
-  if (!config.trackingId) throw new Error('No google analytics trackingId defined')
-  return universalAnalytics(config.trackingId)
+  if (!config.trackingId && !config.tid) throw new Error('No google analytics trackingId defined')
+  if (!config.tid) config.tid = config.trackingId
+  return universalAnalytics(config)
 }
 
 export function pageView({ path, href, title }, client) {


### PR DESCRIPTION
**Update for Google Analytics plugin**

When tracking from server side sometimes is needed to share the `clientId` created in the browser so the tracking on both sides (browser and server) represents the flow done by the same user. 

Now, the Google Analytics can be initialized on the server side only with the `trackingId`, not being able to specify a `clientId`, but the `universal-analytics` library accepts more options on its initialization, including the `clientId`, `userId`, etc.

This PR enables the possibility of initializing the Google Analytics on the server side with all the possible options that `universal-analytics` accepts and also mantaining the actual configuration.