### PR TITLE
fix: error in the do-not-track plugin on safari

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ $ cd analytics
 $ npm run setup
 ```
 
-Because analytics has a large number of packages, we need to also [install watchmen](https://facebook.github.io/watchman/docs/install.html) for better watching.
+Because analytics has a large number of packages, we need to also [install watchman](https://facebook.github.io/watchman/docs/install.html) for better watching.
 
 ```sh
 brew update

--- a/packages/analytics-plugin-do-not-track/src/index.js
+++ b/packages/analytics-plugin-do-not-track/src/index.js
@@ -47,7 +47,8 @@ export function doNotTrackEnabled() {
 
 function msTracking() {
   const { external } = window
-  return 'msTrackingProtectionEnabled' in external &&
+  return typeof external !== 'undefined' &&
+  'msTrackingProtectionEnabled' in external &&
   typeof external.msTrackingProtectionEnabled === 'function' &&
   window.external.msTrackingProtectionEnabled()
 }


### PR DESCRIPTION
When using the do-no-track plugin on Safari, a runtime error is thrown:
```
TypeError: undefined is not an Object. (evaluating ''msTrackingProtectionEnabled' in external')
```

This is due to the fact that `window.external` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Window/external), and as such, it is undefined on Safari.

This change makes sure it is defined before trying to access its properties.

Also, I fixed a typo in CONTRIBUTING.md