### PR TITLE
Adds Custom Dimensions for Node Server GA  

### DIFF
--- a/packages/analytics-plugin-google-analytics/package.json
+++ b/packages/analytics-plugin-google-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@analytics/google-analytics",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Google analytics plugin for 'analytics' module",
   "projectMeta": {
     "provider": {

--- a/packages/analytics-plugin-google-analytics/src/node.js
+++ b/packages/analytics-plugin-google-analytics/src/node.js
@@ -48,7 +48,7 @@ if (!process.browser) {
  */
 function googleAnalytics(pluginConfig = {}) {
   const client = initialize(pluginConfig)
-  const customDimensions = pluginConfig.customDimensions || {};
+  var customDimensions = pluginConfig.customDimensions || {};
   return {
     name: 'google-analytics',
     config: pluginConfig,
@@ -91,9 +91,9 @@ export function pageView({ path, href, title }, client) {
   client.pageview(path, href, title).send()
 }
 
-export function trackEvent({ category, event, label, value, properties }, client) {
+export function trackEvent({ category, event, label, value, properties }, client, customDimensions) {
   // Prepare Custom Dimensions to be Reported.
-  const dimensions = formatObjectIntoDimensions(properties, customDimensions);
+  var dimensions = formatObjectIntoDimensions(properties, customDimensions);
 
   // Send Event.
   client.event(category, event, label, value, dimensions).send()


### PR DESCRIPTION
The @analytics/google-analytics plugin wraps another npm package called "universal-analytics" in order to send Google Analytics data from a Node server environment. This is entirely different from the strategy used for the browser implementation of this plugin.

We add custom dimensions in this PR by:
1. Checking if any user defined custom dimensions configured on the googleAnalytics plugin instance.
2. Checking if a user sent any custom dimensions when firing a .track event.
3. Formatting the custom dimensions and data so they can be sent along with events via universal-analytics.

This PR only adds custom dimensions to events, not page hits or other GA reports. More testing is needed for page hits.
This PR does not add custom metrics either.

I tested this by running `nom build` on the plugin and overwriting a true install of the @analytics/google-analytics plugin with the output. I'm sure there's a better way to do this, but it works. 

Code is pretty well commented. Custom dimensions will now work exactly the same on server side as on browser side as far as usage of the plugin is concerned. Of course under the hood it's a different story.

Solves my issue:
https://github.com/DavidWells/analytics/issues/86

Also worth noting custom dimensions on universal-analytics isn't documented well.
peaksandpies/universal-analytics#82

```
// analytics uses {customDimension[N]: <value>}
// while universal-analytics uses {cd[N]: <value>}
// We use the following object to convert standard analytics syntax into syntax the syntax needed to send an event with the universal-analytics package we're wrapping:

let univeralAnalyticsRosettaStone= {
  dimension1:"cd1",
  dimension2:"cd2",
  dimension3:"cd3",
  dimension4:"cd4",
  dimension5:"cd5",
  dimension6:"cd6",
  dimension7:"cd7",
  dimension8:"cd8",
  dimension9:"cd9",
  dimension10:"cd10",
  dimension11:"cd11",
  dimension12:"cd12",
  dimension13:"cd13",
  dimension14:"cd14",
  dimension15:"cd15",
  dimension16:"cd16",
  dimension17:"cd17",
  dimension18:"cd18",
  dimension19:"cd19",
  dimension20:"cd20"
}
```

@DavidWells let me know what you think :) and thanks again for the dope library!