### PR TITLE
fix: check for global instance of mixpanel plugin

### DIFF
--- a/packages/analytics-plugin-mixpanel/src/browser.js
+++ b/packages/analytics-plugin-mixpanel/src/browser.js
@@ -23,7 +23,7 @@ function mixpanelPlugin(pluginConfig = {}) {
       }
 
       // NoOp if mixpanel already loaded by external source or already loaded
-      if (mixpanel || isMixpanelLoaded) {
+      if (window.mixpanel || isMixpanelLoaded) {
         return;
       }
 


### PR DESCRIPTION
Mixpanel plugin is failing with ReferenceError. Checking for the global instance on window solves the issue.

![Screen Shot 2020-11-04 at 14 45 11](https://user-images.githubusercontent.com/14997380/98119188-905aa580-1eac-11eb-8772-4311c52cc8c3.png)
