### PR TITLE
fix: segment page call requires a userId or anonymousId 

### DIFF
--- a/packages/analytics-plugin-segment/src/node.js
+++ b/packages/analytics-plugin-segment/src/node.js
@@ -61,9 +61,18 @@ function segmentPlugin(userConfig = {}) {
     },
     /* page view */
     page: ({ payload, config }) => {
-      client.page({
-        properties: payload.properties
-      })
+      const { userId, anonymousId } = payload
+      if (!userId && !anonymousId) {
+        throw new Error('Missing userId and anonymousId. You must include one to make segment call')
+      }
+
+      const data = {
+        properties: payload.properties,
+        anonymousId,
+        userId
+      }
+
+      client.page(data)
     },
     /* track event */
     track: ({ payload, config }) => {


### PR DESCRIPTION
Before this change:

```
(node:921) UnhandledPromiseRejectionWarning: AssertionError [ERR_ASSERTION]: You must pass either an "anonymousId" or a "userId".
    at validatePageEvent (/node_modules/@segment/loosely-validate-event/index.js:67:3)
    at looselyValidateEvent (/node_modules/@segment/loosely-validate-event/index.js:26:14)
    at Analytics._validate (/node_modules/analytics-node/index.js:58:7)
    at Analytics.page (/node_modules/analytics-node/index.js:119:10)
    at Object.page (/node_modules/@analytics/segment/lib/analytics-plugin-segment.cjs.js:111:14)
    at _callee4$ (/node_modules/@analytics/core/lib/analytics.cjs.js:2441:53)
    at tryCatch (/node_modules/@analytics/core/lib/analytics.cjs.js:1058:40)
    at Generator.invoke [as _invoke] (/node_modules/@analytics/core/lib/analytics.cjs.js:1287:22)
    at Generator.prototype.<computed> [as next] (/node_modules/@analytics/core/lib/analytics.cjs.js:1110:21)
    at asyncGeneratorStep (/node_modules/@analytics/core/lib/analytics.cjs.js:1749:24)
    at _next (/node_modules/@analytics/core/lib/analytics.cjs.js:1771:9)
```