### PR TITLE
Improve typescript support

### DIFF
--- a/jsdoc.config.js
+++ b/jsdoc.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: [
+    'jsdoc-plugin-intersection'
+  ],
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "dox": "^0.9.0",
     "indent-string": "^4.0.0",
     "jsdoc": "^3.6.3",
+    "jsdoc-plugin-intersection": "^1.0.4",
     "lerna": "^3.10.7",
     "markdown-magic": "^0.1.25",
     "mkdirp": "^0.5.1",

--- a/packages/analytics-core/package.json
+++ b/packages/analytics-core/package.json
@@ -26,7 +26,7 @@
     "test:watch": "ava -v --watch",
     "clean": "rimraf lib dist && mkdirp lib dist",
     "prebuild": "npm run clean && npm run types",
-    "types": "../../node_modules/.bin/jsdoc -t ../../node_modules/tsd-jsdoc/dist -r ./src/ -d temp-types && node scripts/types.js",
+    "types": "../../node_modules/.bin/jsdoc -c ../../jsdoc.config.js -t ../../node_modules/tsd-jsdoc/dist -r ./src/ -d temp-types && node scripts/types.js",
     "build": "node ../../scripts/build/index.js",
     "postbuild": "npm run minify-dist && node ./scripts/postbuild.js",
     "watch": "node ../../scripts/build/_watch.js",

--- a/packages/analytics-core/scripts/types.js
+++ b/packages/analytics-core/scripts/types.js
@@ -11,17 +11,55 @@ const content = fs.readFileSync(TYPES_PATH, 'utf-8')
 const typesFromJsDocs = content
   // Remove declares
   .replace(/^declare\s/gm, '')
-  // Export analytics instance
-  .replace(/type AnalyticsInstance =/gm, 'export type AnalyticsInstance =')
+  // Export user-facing types (and where possible, convert objects to interface so they can be extended)
+  .replace(/type AnalyticsInstance =/gm, 'export interface AnalyticsInstance ')
+  .replace(/type AnalyticsInstanceConfig =/gm, 'export interface AnalyticsInstanceConfig ')
+  .replace(/type (\w+)Payload =/gm, match => `export ${match}`)
+  // Exported so user doesn't have to do ReturnType to get them
+  .replace(/type DetachListeners =/gm, 'export type DetachListeners =')
+
+  // Convert following types to generics to be able to pass payload type throught them
+  // Export hooks and convert them to generics accepting payload type
+  .replace(
+    /type (\w+)Hook =(.*)Context/gm,
+    (_, typeName, argsDefStart) => `export type ${typeName}Hook<T = ${typeName}Payload> =${argsDefStart}Context<T>`,
+  )
+  // Convert contexts to generics accepting payload type
+  .replace(
+    /type (\w+)Context =(.*)ContextProps(\W)/gm,
+    (_, typeName, typeDefStart, typeDefEnd) => `type ${typeName}Context<T = ${typeName}Payload> =${typeDefStart}ContextProps<T>${typeDefEnd}`,
+  )
+  // Convert context props types to generics accepting payload type
+  .replace(
+    /type (\w+)ContextProps =((.|\s)*?)payload: \w+/gm,
+    (_, typeName, typeDefStart) => `type ${typeName}ContextProps<T = ${typeName}Payload> =${typeDefStart}payload: T`,
+  )
+
+  // Rename following types so we can set generics in their place
+  .replace(/type AnalyticsPlugin = /gm, 'interface AnalyticsPluginBase ')
+  .replace(/type PageData = /gm, 'interface PageDataBase ')
   // Make promises return void
   .replace(/\@returns \{Promise\}/gm, '@returns {Promise<void>}')
   .replace(/=> Promise;/gm, '=> Promise<any>;')
-  // Fix plugin interface
-  .replace(/plugins\?: object\[\]/gm, 'plugins?: Array<AnalyticsPlugin>')
+  // Convert unions ('|') to joins ('&').
+  // Joins are used for modular JSDOC typedefs that support intellisense in VS Code.
+  // 'jsdoc' cannot parse joins, so they are temporarily transpiled to unions by 'jsdoc-plugin-intersection'.
+  .replace(/ \| /gm, ' & ')
+
+// Make types extensible
+const typeExtensions = `
+
+  export type PageData<T extends string = string> = PageDataBase & Record<T, unknown>;
+  export type AnalyticsPlugin<T extends string = string> = AnalyticsPluginBase & string extends T
+    ? Record<string, unknown>
+    : Record<T, Hook> & Record<string, unknown>;
+`;
 
 // Expose main API
 const newContent = `declare module "analytics" {
 ${indentString(typesFromJsDocs, 2)}
+${typeExtensions}
+
   export const CONSTANTS: constants;
 
   export const init: typeof analytics;

--- a/packages/analytics-core/src/events.js
+++ b/packages/analytics-core/src/events.js
@@ -106,7 +106,7 @@ export const coreEvents = [
    */
   'identifyEnd',
   /**
-   * `identifyAborted` - Fires if 'track' call is cancelled by a plugin
+   * `identifyAborted` - Fires if 'identify' call is cancelled by a plugin
    */
   'identifyAborted',
   /**

--- a/packages/analytics-core/src/middleware/identify.js
+++ b/packages/analytics-core/src/middleware/identify.js
@@ -29,7 +29,8 @@ export default function identifyMiddleware(instance) {
       const currentTraits = getItem(USER_TRAITS) || {}
 
       if (currentId && (currentId !== userId)) {
-        store.dispatch({
+        /** @type {UserIdChangedPayload} */
+        const userIdChangedPayload = {
           type: EVENTS.userIdChanged,
           old: {
             userId: currentId,
@@ -40,7 +41,8 @@ export default function identifyMiddleware(instance) {
             traits
           },
           options: options,
-        })
+        };
+        store.dispatch(userIdChangedPayload);
       }
 
       /* Save user id */

--- a/packages/analytics-core/src/middleware/plugins/index.js
+++ b/packages/analytics-core/src/middleware/plugins/index.js
@@ -30,6 +30,7 @@ export default function pluginMiddleware(instance, getPlugins, systemEvents) {
         acc[curr] = allPlugins[curr]
         return acc
       }, {})
+      /** @type {InitializePayload} */
       const initializeAction = {
         type: EVENTS.initializeStart,
         plugins: action.plugins
@@ -82,11 +83,13 @@ export default function pluginMiddleware(instance, getPlugins, systemEvents) {
         // setTimeout to ensure runs after 'page'
         setTimeout(() => {
           if (pluginsArray.length === allCalls.length) {
-            store.dispatch({
+            /** @type {ReadyPayload} */
+            const readyPayload = {
               type: EVENTS.ready,
               plugins: completed,
               failed: failed
-            })
+            };
+            store.dispatch(readyPayload);
           }
         }, 0)
       })

--- a/packages/analytics-core/src/middleware/storage.js
+++ b/packages/analytics-core/src/middleware/storage.js
@@ -19,22 +19,24 @@ export default function storageMiddleware(storage) {
   }
 }
 
-export const setItem = (key, value, opts) => {
+export const setItem = (key, value, options) => {
+  /** @type {SetItemPayload} */
   return {
     type: EVENTS.setItemStart,
     timestamp: timestamp(),
-    key: key,
-    value: value,
-    options: opts,
+    key,
+    value,
+    options,
   }
 }
 
-export const removeItem = (key, opts) => {
+export const removeItem = (key, options) => {
+  /** @type {RemoveItemPayload} */
   return {
     type: EVENTS.removeItemStart,
     timestamp: timestamp(),
-    key: key,
-    options: opts,
+    key,
+    options,
   }
 }
 

--- a/packages/analytics-core/src/modules/plugins.js
+++ b/packages/analytics-core/src/modules/plugins.js
@@ -97,6 +97,7 @@ export default function createReducer(getPlugins) {
 }
 
 export const enablePlugin = (name, callback) => {
+  /** @type {EnablePluginPayload} */
   return {
     type: EVENTS.enablePlugin,
     name: name,
@@ -108,6 +109,7 @@ export const enablePlugin = (name, callback) => {
 }
 
 export const disablePlugin = (name, callback) => {
+  /** @type {EnablePluginPayload} */
   return {
     type: EVENTS.disablePlugin,
     name: name,

--- a/packages/analytics-core/src/pluginTypeDef.js
+++ b/packages/analytics-core/src/pluginTypeDef.js
@@ -1,12 +1,500 @@
+//////////////////
+// Plugins
+//////////////////
+
 /**
-  * @typedef {Object} AnalyticsPlugin
-  * @property {string} name - Name of plugin
-  * @property {Object} [EVENTS] - exposed events of plugin
-  * @property {Object} [config] - Configuration of plugin
-  * @property {function} [initialize] - Load analytics scripts method
-  * @property {function} [page] - Page visit tracking method
-  * @property {function} [track] - Custom event tracking method
-  * @property {function} [identify] - User identify method
-  * @property {function} [loaded] - Function to determine if analytics script loaded
-  * @property {function} [ready] - Fire function when plugin ready
+ * @typedef {Object} AnalyticsPlugin
+ * @property {string} name Name of plugin
+ * @property {Object} [EVENTS] Exposed events of plugin
+ * @property {Object} [config] Configuration of plugin
+ * @property {Hook} [loaded] - Function to determine if analytics script loaded
+ * @property {BootstrapHook} [bootstrap] Fires when analytics library starts up
+ * @property {ParamsHook} [params] Fires when analytics parses URL parameters
+ * @property {CampaignHook} [campaign] Fires if params contain "utm" parameters
+ * @property {InitializeHook} [initializeStart] Fires before 'initialize', allows for plugins to cancel loading of other plugins
+ * @property {InitializeHook} [initialize] Fires when analytics loads plugins
+ * @property {InitializeHook} [initializeEnd] Fires after initialize, allows for plugins to run logic after initialization methods run
+ * @property {ReadyHook} [ready] Fires when all analytic providers are fully loaded. This waits for 'initialize' and 'loaded' to return true
+ * @property {ResetHook} [resetStart] Fires if analytic.reset() is called.
+ * @property {ResetHook} [reset] Fires if analytic.reset() is called.
+ * @property {ResetHook} [resetEnd] Fires after analytic.reset() is called.
+ * @property {PageHook} [pageStart] Fires before 'page' events fire.
+ * @property {PageHook} [page] Core analytics hook for page views.
+ * @property {PageHook} [pageEnd] Fires after all registered 'page' methods fire.
+ * @property {PageHook} [pageAborted] Fires if 'page' call is cancelled by a plugin
+ * @property {TrackHook} [trackStart] Called before the 'track' events fires.
+ * @property {TrackHook} [track] Core analytics hook for event tracking.
+ * @property {TrackHook} [trackEnd] Fires after all registered 'track' events fire from plugins.
+ * @property {TrackHook} [trackAborted] Fires if 'track' call is cancelled by a plugin
+ * @property {IdentifyHook} [identifyStart] Called before the 'identify' events fires.
+ * @property {IdentifyHook} [identify] Core analytics hook for user identification.
+ * @property {IdentifyHook} [identifyEnd] Fires after all registered 'identify' events fire from plugins.
+ * @property {IdentifyHook} [identifyAborted] Fires if 'identify' call is cancelled by a plugin
+ * @property {UserIdChangedHook} [userIdChanged] Fires when a user id is updated
+ * @property {RegisterPluginsHook} [registerPlugins] Fires when analytics is registering plugins
+ * @property {EnablePluginHook} [enablePlugin] Fires when 'analytics.enablePlugin()' is called
+ * @property {EnablePluginHook} [disablePlugin] Fires when 'analytics.disablePlugin()' is called
+ * @property {EnablePluginHook} [loadPlugin] Fires when 'analytics.loadPlugin()' is called
+ * @property {EmptyHook} [online] Fires when browser network goes online.
+ * @property {EmptyHook} [offline] Fires when browser network goes offline.
+ * @property {SetItemHook} [setItemStart] Fires when analytics.storage.setItem is initialized.
+ * @property {SetItemHook} [setItem] Fires when analytics.storage.setItem is called.
+ * @property {SetItemHook} [setItemEnd] Fires when setItem storage is complete.
+ * @property {SetItemHook} [setItemAborted] Fires when setItem storage is cancelled by a plugin.
+ * @property {RemoveItemHook} [removeItemStart] Fires when analytics.storage.removeItem is initialized.
+ * @property {RemoveItemHook} [removeItem] Fires when analytics.storage.removeItem is called.
+ * @property {RemoveItemHook} [removeItemEnd] Fires when removeItem storage is complete.
+ * @property {RemoveItemHook} [removeItemAborted] Fires when removeItem storage is cancelled by a plugin.
+ */
+
+/**
+ * @typedef {Object} PluginState State of a plugin
+ * @property {Object} [config] Configuration of plugin
+ * @property {Boolean} enabled Whether plugin is enabled
+ * @property {Boolean} initialized Whether plugin is initialized
+ * @property {Boolean} loaded Whether plugin is loaded
+ */
+
+/**
+  * @typedef {Function} Abort
+  * @returns  {void}
   */
+
+//////////////////
+// Hooks
+//////////////////
+
+// Hooks - Generic
+
+/**
+ * @typedef {Object} PayloadBase
+ * @property {String} type - Event type
+ */
+
+/**
+ * @typedef {PayloadBase} EmptyPayload
+ */
+
+/**
+ * @typedef {Object} EmptyContextProps
+ * @property {PayloadBase} payload Empty payload in hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & EmptyContextProps} EmptyContext Context with empty payload passed to a hook
+ */
+
+ /**
+ * @typedef {Function} EmptyHook
+ * @param  {EmptyContext} context Context with empty payload passed to a base hook
+ */
+
+/**
+  * @typedef {Object} HookContextBase Base of the context passed to a generic plugin hook
+  * @property  {string} hello Name of current plugin
+  * @property  {AnalyticsInstance} instance Analytics instance
+  * @property  {Object} [config] Configuration of plugin
+  */
+
+/**
+  * @typedef {Object} HookContextPropsCommon
+  * @property  {Object.<string, PluginState>} plugins Name of plugins(s) to disable
+  * @property  {Abort} abort Name of plugins(s) to disable
+  */
+
+/**
+  * @typedef {HookContextBase & HookContextPropsCommon} HookContextCommon
+  */
+
+/**
+ * @typedef {PayloadBase} HookPayload Payload in any hook
+ */
+
+/**
+  * @typedef {Object} HookContextProps
+  * @property {Object} payload Payload in any hook
+  */
+
+/**
+  * @typedef {HookContextCommon & HookContextProps} HookContext Context passed to a generic plugin hook
+  * @property  {Object} payload Name of plugins(s) to disable
+  */
+
+/**
+ * @typedef {Function} Hook Generic hook on the AnalyticsPlugin object.
+ * @param  {HookContext} context Context passed to a plugin hook
+ */
+
+// Hooks - Bootstrap
+
+/**
+ * @typedef {AnalyticsPlugin} BootstrapPayload Payload in any hook
+ */
+
+/**
+ * @typedef {Object} BootstrapContextProps Context passed to bootstrap hook
+ * @property {BootstrapPayload} payload Analytics plugin
+ */
+
+ /**
+ * @typedef {HookContextCommon & BootstrapContextProps} BootstrapContext Context passed to bootstrap hook
+ */
+
+ /**
+ * @typedef {Function} BootstrapHook
+ * @param  {BootstrapContext} context Context passed to bootstrap hook
+ * @returns  {void}
+ */
+
+// Hooks - Params
+
+/**
+ * @typedef {Object} ParamsPayloadProps Payload in params hook
+ * @property {Object.<string, string>} raw Raw search params
+ * @property {Object.<string, string>} props Props search params
+ * @property {Object.<string, string>} traits Traits search params
+ * @property {String} [userId] User ID.
+ */
+
+ /**
+ * @typedef {PayloadBase & CampaignPayloadProps & ParamsPayloadProps} ParamsPayload Payload in params hook
+ */
+
+ /**
+ * @typedef {Object} ParamsContextProps
+ * @property {ParamsPayload} payload Payload in params hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & ParamsContextProps} ParamsContext Context passed to params hook
+ */
+
+ /**
+ * @typedef {Function} ParamsHook
+ * @param  {ParamsContext} context Context passed to params hook
+ */
+
+// Hooks - Campaign
+
+/**
+ * @typedef {Object} CampaignPayloadProps
+ * @property {Object.<string, string>} campaign UTM search params
+ */
+
+ /**
+ * @typedef {PayloadBase & CampaignPayloadProps} CampaignPayload Payload in campaign hook
+ */
+
+ /**
+ * @typedef {Object} CampaignContextProps
+ * @property {CampaignPayload} payload Payload in campaign hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & CampaignContextProps} CampaignContext Context passed to campaign hook
+ */
+
+ /**
+ * @typedef {Function} CampaignHook
+ * @param  {CampaignContext} context Context passed to campaign hook
+ */
+
+// Hooks - Initialize
+
+/**
+ * @typedef {Object} InitializePayloadProps
+ * @property {Array.<string>} plugins Names of plugins
+ */
+
+ /**
+ * @typedef {PayloadBase & InitializePayloadProps} InitializePayload Payload in initialize hook
+ */
+
+ /**
+ * @typedef {Object} InitializeContextProps
+ * @property {InitializePayload} payload Payload in initialize hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & InitializeContextProps} InitializeContext Context passed to initialize hook
+ */
+
+ /**
+ * @typedef {Function} InitializeHook
+ * @param  {InitializeContext} context Context passed to initialize hook
+ */
+
+// Hooks - Ready
+
+/**
+ * @typedef {Object} ReadyPayloadProps
+ * @property {Array.<string>} failed Names of failed plugins
+ */
+
+ /**
+ * @typedef {PayloadBase & InitializePayloadProps & ReadyPayloadProps} ReadyPayload Payload in ready hook
+ */
+
+ /**
+ * @typedef {Object} ReadyContextProps
+ * @property {ReadyPayload} payload Payload in ready hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & ReadyContextProps} ReadyContext Context passed to ready hook
+ */
+
+/**
+ * @typedef {Function} ReadyHook
+ * @param  {ReadyContext} context Context passed to ready hook
+ */
+
+// Hooks - Reset
+
+/**
+ * @typedef {Object} ResetPayloadProps
+ * @property {Number} timestamp
+ * @property {Function} callback
+ */
+
+ /**
+ * @typedef {PayloadBase & ResetPayloadProps} ResetPayload Payload in reset hook
+ */
+
+ /**
+ * @typedef {Object} ResetContextProps
+ * @property {ResetPayload} payload Payload in reset hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & ResetContextProps} ResetContext Context passed to reset hook
+ */
+
+ /**
+ * @typedef {Function} ResetHook
+ * @param  {ResetContext} context Context passed to reset hook
+ */
+
+// Hooks - Page
+
+/**
+ * @typedef {Object} PagePayloadProps
+ * @property {String} anonymousId
+ * @property {String} userId
+ * @property {ResetPayloadProps} meta
+ * @property {Object} properties
+ * @property {Object} options
+ */
+
+ /**
+ * @typedef {PayloadBase & PagePayloadProps} PagePayload Payload in page hook
+ */
+
+ /**
+ * @typedef {Object} PageContextProps
+ * @property {PagePayload} payload Payload in page hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & PageContextProps} PageContext Context passed to page hook
+ */
+
+ /**
+ * @typedef {Function} PageHook
+ * @param  {PageContext} context Context passed to page hook
+ */
+
+// Hooks - Track
+
+/**
+ * @typedef {Object} TrackPayloadProps
+ * @property {String} anonymousId
+ * @property {String} userId
+ * @property {String} event
+ * @property {ResetPayloadProps} meta
+ * @property {Object} properties
+ * @property {Object} options
+ */
+
+ /**
+ * @typedef {PayloadBase & TrackPayloadProps} TrackPayload Payload in track hook
+ */
+
+ /**
+ * @typedef {Object} TrackContextProps
+ * @property {TrackPayload} payload Payload in track hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & TrackContextProps} TrackContext Context passed to track hook
+ */
+
+ /**
+ * @typedef {Function} TrackHook
+ * @param  {TrackContext} context Context passed to track hook
+ */
+
+// Hooks - Identify
+
+/**
+ * @typedef {Object} IdentifyPayloadProps
+ * @property {String} anonymousId
+ * @property {String} userId
+ * @property {ResetPayloadProps} meta
+ * @property {Object} traits
+ * @property {Object} options
+ */
+
+ /**
+ * @typedef {PayloadBase & IdentifyPayloadProps} IdentifyPayload Payload in identify hook
+ */
+
+ /**
+ * @typedef {Object} IdentifyContextProps
+ * @property {IdentifyPayload} payload Payload in identify hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & IdentifyContextProps} IdentifyContext Context passed to identify hook
+ */
+
+ /**
+ * @typedef {Function} IdentifyHook
+ * @param  {IdentifyContext} context Context passed to identify hook
+ */
+
+// Hooks - UserIdChanged
+
+/**
+ * @typedef {Object} UserIdChangedState
+ * @property {String} userId
+ * @property {Object} traits
+ */
+
+ /**
+ * @typedef {Object} UserIdChangedPayloadProps
+ * @property {UserIdChangedState} new
+ * @property {UserIdChangedState} old
+ * @property {Object} options
+ */
+
+ /**
+ * @typedef {PayloadBase & UserIdChangedPayloadProps} UserIdChangedPayload Payload in userIdChanged hook
+ */
+
+ /**
+ * @typedef {Object} UserIdChangedContextProps
+ * @property {UserIdChangedPayload} payload Payload in userIdChanged hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & UserIdChangedContextProps} UserIdChangedContext Context passed to userIdChanged hook
+ */
+
+ /**
+ * @typedef {Function} UserIdChangedHook
+ * @param  {UserIdChangedContext} context Context passed to userIdChanged hook
+ */
+
+// Hooks - RegisterPlugins
+
+/**
+ * @typedef {Object} RegisterPluginsPayloadProps
+ * @property {Array.<String>} plugins
+ */
+
+ /**
+ * @typedef {PayloadBase & RegisterPluginsPayloadProps} RegisterPluginsPayload Payload in RegisterPlugins hook
+ */
+
+ /**
+ * @typedef {Object} RegisterPluginsContextProps
+ * @property {RegisterPluginsPayload} payload Payload in registerPlugins hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & RegisterPluginsContextProps} RegisterPluginsContext Context passed to registerPlugins hook
+ */
+
+ /**
+ * @typedef {Function} RegisterPluginsHook
+ * @param  {RegisterPluginsContext} context Context passed to registerPlugins hook
+ */
+
+// Hooks - EnablePlugin
+
+/**
+ * @typedef {Object} EnablePluginPayloadProps
+ * @property {Function} [callback]
+ * @property {String} name
+ */
+
+ /**
+ * @typedef {PayloadBase & EnablePluginPayloadProps} EnablePluginPayload Payload in enablePlugin hook
+ */
+
+ /**
+ * @typedef {Object} EnablePluginContextProps
+ * @property {EnablePluginPayload} payload Payload in enablePlugin hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & EnablePluginContextProps} EnablePluginContext Context passed to enablePlugin hook
+ */
+
+ /**
+ * @typedef {Function} EnablePluginHook
+ * @param  {EnablePluginContext} context Context passed to enablePlugin hook
+ */
+
+// Hooks - RemoveItem
+
+/**
+ * @typedef {Object} RemoveItemPayloadProps
+ * @property {String} key
+ * @property {Number} timestamp
+ * @property {Object} [options]
+ */
+
+ /**
+ * @typedef {PayloadBase & RemoveItemPayloadProps} RemoveItemPayload Payload in removeItem hook
+ */
+
+ /**
+ * @typedef {Object} RemoveItemContextProps
+ * @property {RemoveItemPayload} payload Payload in removeItem hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & RemoveItemContextProps} RemoveItemContext Context passed to removeItem hook
+ */
+
+ /**
+ * @typedef {Function} RemoveItemHook
+ * @param  {RemoveItemContext} context Context passed to removeItem hook
+ */
+
+// Hooks - SetItem
+
+/**
+ * @typedef {Object} SetItemPayloadProps
+ * @property {*} [value]
+ */
+
+ /**
+ * @typedef {PayloadBase & RemoveItemPayloadProps & SetItemPayloadProps} SetItemPayload Payload in setItem hook
+ */
+
+ /**
+ * @typedef {Object} SetItemContextProps
+ * @property {SetItemPayload} payload Payload in setItem hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & SetItemContextProps} SetItemContext Context passed to setItem hook
+ */
+
+ /**
+ * @typedef {Function} SetItemHook
+ * @param  {SetItemContext} context Context passed to setItem hook
+ */


### PR DESCRIPTION
**Background**

Working with the `analytics` package revolves around writing hooks on a custom `AnalyticsPlugin` object.

As a heavy TypeScript user, lacking the type support for hook methods feels insecure. It slows down the workflow as I don't know which hook provides what data in the context object passed to that hook, so I usually resolve to running live demo and debugging. Lacking type support is also an issue for maintainability.

To address these issues, this MR adds JSDoc typedefs for `AnalyticsPlugin`-related interfaces that cover what data is passed to which hook, so that proper types can be generated in `types.d.ts`.

To achieve that, the type annotations had to be written and `types.d.ts` file postprocessing had to be updated. 

To keep things DRY and managable, the typedefs were written modularly, e.g. `/** @typedef {HookContextCommon & EmptyContextProps} EmptyContext */`.

While this worked well for intellisense, there was a compatibility issue when trying to parse the annotations with `jsdoc`, which is done when generating TypeScript types out of the JSDoc annotations.

This was overcome by defining a jsdoc config and using `jsdoc-plugin-intersection` package with it. The package converts type joins to unions, so that jsdoc can parse the annotation and generate TS types. However, the generated types are with the unions instead of joins, so this had to be additionally fixed when transforming the content of `.d.ts`.

Lastly, when I was searching for where are individual payloads defined - so I could document them - I also added `@type` tags to the data to improve searchability, as at first it wasn't easy to navigate the `analytics-core` package.

**Changes**

- Add plugin `@typedefs` annotations to `pluginTypeDef.js`
- Add `@type` annotations for payload definitions throughout `analytics-core`
- Add `jsdoc-plugin-intersection` as devDep
- Add `jsdoc.config.js` and use `jsdoc-plugin-intersection` in it
- Add transformations on `types.d.ts` to:
  - Export user-facing types
  - Type joins
  - Extend some of existing types to make them into generics.


**Demo**

These changes provide typing for inside the hooks.

<details>
<summary>
  Screenshot
</summary>

The typing supports hooks for all events defined in `events.js`. For custom events, these can be specified as a union of strings and passed to the `AnalyticsPlugin` generic. The generic parameter is optional. In that case, the type added is a generic hook type, which covers most of the context object passed to the hook. But the payload is `any`. If you want to specify a particular type of hook interface, this can be achieved with a union, as shown in the first line.

<img width="679" alt="Screenshot 2020-11-15 at 00 10 38" src="https://user-images.githubusercontent.com/25986782/99159730-34c3bf80-26d7-11eb-8d1d-4fb3d266a3c7.png">

</details>

The generated `types.d.ts` with the changes applied is below (uploaded with `.txt` suffix because GitHub didn't allow other:

[types.txt](https://github.com/DavidWells/analytics/files/5541617/types.txt)