### PR TITLE
Mixpanel improvements

### DIFF
--- a/packages/analytics-plugin-mixpanel/package.json
+++ b/packages/analytics-plugin-mixpanel/package.json
@@ -50,5 +50,13 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.3.1"
+  },
+  "peerDependencies": {
+    "mixpanel-browser": "^2.0.0"
+  },
+  "peerDependenciesMeta": {   
+    "mixpanel-browser": {     
+      "optional": true   
+    }
   }
 }

--- a/packages/analytics-plugin-mixpanel/src/browser.js
+++ b/packages/analytics-plugin-mixpanel/src/browser.js
@@ -3,6 +3,9 @@ import browserLoadMixpanel from './browserLoadMixpanel';
 /**
   * @typedef {Object} MixpanelPluginConfig - Plugin settings for Mixpanel plugin
   * @property {String} [token] - The mixpanel token associated to a mixpanel project
+  * @property {Object} [mixpanel] - The mixpanel instance - use this
+  *   to use the plugin with a mixpanel instance instantiated elsewhere, for
+  *   example when using a mixpanel npm package.
   * @property {Object} [context] - The context object where mixpanel
   *   instance is found and assigned to when instantiated. Defaults to window.
   */
@@ -13,8 +16,8 @@ import browserLoadMixpanel from './browserLoadMixpanel';
  * @returns {Object} Mixpanel instance
  */
 const resolveMixpanel = (config = {}) => {
-  const { context = window } = config;
-  return context.mixpanel;
+  const { context = window, mixpanel: givenMixpanel } = config;
+  return givenMixpanel || context.mixpanel;
 }
 
 /**
@@ -36,6 +39,11 @@ const resolveMixpanel = (config = {}) => {
  *   context: myContext,
  * });
  *
+ * // Use existing mixpanel instance
+ * import mixpanel from 'mixpanel-browser';
+ * mixpanelPlugin({
+ *   mixpanel: mixpanel.init('abcdef123'),
+ * });
  */
 function mixpanelPlugin(pluginConfig = {}) {
   const plugin = {

--- a/packages/analytics-plugin-mixpanel/src/browser.js
+++ b/packages/analytics-plugin-mixpanel/src/browser.js
@@ -1,122 +1,70 @@
+import browserLoadMixpanel from './browserLoadMixpanel';
+
+/**
+  * @typedef {Object} MixpanelPluginConfig - Plugin settings for Mixpanel plugin
+  * @property {String} [token] - The mixpanel token associated to a mixpanel project
+  * @property {Object} [context] - The context object where mixpanel
+  *   instance is found and assigned to when instantiated. Defaults to window.
+  */
+
+/**
+ * Get mixpanel instance from config
+ * @param {MixpanelPluginConfig} config
+ * @returns {Object} Mixpanel instance
+ */
+const resolveMixpanel = (config = {}) => {
+  const { context = window } = config;
+  return context.mixpanel;
+}
+
 /**
  * Mixpanel Analytics plugin
  * @link https://getanalytics.io/plugins/mixpanel/
- * @param {object} pluginConfig - Plugin settings
- * @param {string} pluginConfig.token - The mixpanel token associated to a mixpanel project
- * @return {object} Analytics plugin
+ * @param {MixpanelPluginConfig} pluginConfig - Plugin settings
+ * @return {AnalyticsPlugin} Analytics plugin
  * @example
  *
+ * // Load Mixpanel instance to `window`
  * mixpanelPlugin({
- *   token: 'abcdef123'
- * })
+ *   token: 'abcdef123',
+ * });
+ *
+ * // Load Mixpanel instance to `context` object instead of `window`
+ * const myContext = {};
+ * mixpanelPlugin({
+ *   token: 'abcdef123',
+ *   context: myContext,
+ * });
+ *
  */
 function mixpanelPlugin(pluginConfig = {}) {
-  return {
+  const plugin = {
     NAMESPACE: "mixpanel",
     config: pluginConfig,
     /* https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelinit */
     initialize: ({ config }) => {
-      const { token } = config;
-      if (!token) {
-        throw new Error("No mixpanel token defined");
-      }
+      const {
+        token,
+        context = window,
+      } = config || {};
 
-      // NoOp if mixpanel already loaded by external source or already loaded
-      if (typeof window.mixpanel !== 'undefined') {
+      let mixpanel = resolveMixpanel(config);
+
+      const hasMixpanel = Boolean(mixpanel);
+
+      if (hasMixpanel) {
+        // NoOp if mixpanel already loaded by external source or already loaded
         return;
       }
 
-      // Load mixpanel library
-      (function(c, a) {
-        if (!a.__SV) {
-          var b = window;
-          try {
-            var d,
-              m,
-              j,
-              k = b.location,
-              f = k.hash;
-            d = function(a, b) {
-              return (m = a.match(RegExp(b + "=([^&]*)"))) ? m[1] : null;
-            };
-            f &&
-              d(f, "state") &&
-              ((j = JSON.parse(decodeURIComponent(d(f, "state")))),
-              "mpeditor" === j.action &&
-                (b.sessionStorage.setItem("_mpcehash", f),
-                history.replaceState(
-                  j.desiredHash || "",
-                  c.title,
-                  k.pathname + k.search
-                )));
-          } catch (n) {}
-          var l, h;
-          window.mixpanel = a;
-          a._i = [];
-          a.init = function(b, d, g) {
-            function c(b, i) {
-              var a = i.split(".");
-              2 == a.length && ((b = b[a[0]]), (i = a[1]));
-              b[i] = function() {
-                b.push([i].concat(Array.prototype.slice.call(arguments, 0)));
-              };
-            }
-            var e = a;
-            "undefined" !== typeof g ? (e = a[g] = []) : (g = "mixpanel");
-            e.people = e.people || [];
-            e.toString = function(b) {
-              var a = "mixpanel";
-              "mixpanel" !== g && (a += "." + g);
-              b || (a += " (stub)");
-              return a;
-            };
-            e.people.toString = function() {
-              return e.toString(1) + ".people (stub)";
-            };
-            l = "disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(
-              " "
-            );
-            for (h = 0; h < l.length; h++) c(e, l[h]);
-            var f = "set set_once union unset remove delete".split(" ");
-            e.get_group = function() {
-              function a(c) {
-                b[c] = function() {
-                  call2_args = arguments;
-                  call2 = [c].concat(Array.prototype.slice.call(call2_args, 0));
-                  e.push([d, call2]);
-                };
-              }
-              for (
-                var b = {},
-                  d = ["get_group"].concat(
-                    Array.prototype.slice.call(arguments, 0)
-                  ),
-                  c = 0;
-                c < f.length;
-                c++
-              )
-                a(f[c]);
-              return b;
-            };
-            a._i.push([b, d, g]);
-          };
-          a.__SV = 1.2;
-          b = c.createElement("script");
-          b.type = "text/javascript";
-          b.async = !0;
-          b.src =
-            "undefined" !== typeof MIXPANEL_CUSTOM_LIB_URL
-              ? MIXPANEL_CUSTOM_LIB_URL
-              : "file:" === c.location.protocol &&
-                "//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)
-              ? "https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js"
-              : "//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";
-          d = c.getElementsByTagName("script")[0];
-          d.parentNode.insertBefore(b, d);
+      if (!hasMixpanel) {
+        if (!token) {
+          throw new Error("No mixpanel token defined");
         }
-      })(document, window.mixpanel || []);
 
-      mixpanel.init(config.token, { batch_requests: true });
+        mixpanel = browserLoadMixpanel(context);
+        mixpanel.init(token, { batch_requests: true });
+      }
     },
     /**
      * Identify a visitor in mixpanel
@@ -125,8 +73,10 @@ function mixpanelPlugin(pluginConfig = {}) {
      * Mixpanel doesn't allow to set properties directly in identify, so mixpanel.people.set is
      * also called if properties are passed
      */
-    identify: ({ payload }) => {
+    identify: ({ config, payload }) => {
+      const mixpanel = resolveMixpanel(config);
       const { userId, traits } = payload;
+
       if (typeof userId === "string") {
         mixpanel.identify(userId);
       }
@@ -138,20 +88,24 @@ function mixpanelPlugin(pluginConfig = {}) {
      * Mixpanel doesn't have a "page" function, so we are using the track method by sending
      * the path as tracked event and search parameters as properties
      */
-    page: ({ payload }) => {
+    page: ({ config, payload }) => {
+      const mixpanel = resolveMixpanel(config);
       mixpanel.track(payload.properties.path, {
         search: payload.properties.search,
       });
     },
     /* https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpaneltrack */
-    track: ({ payload }) => {
+    track: ({ config, payload }) => {
+      const mixpanel = resolveMixpanel(config);
       mixpanel.track(payload.event, payload.properties);
     },
     loaded: () => {
-      return !!window.mixpanel;
+      const mixpanel = resolveMixpanel(plugin.config);
+      return !!mixpanel;
     },
     /* Clears super properties and generates a new random distinct_id for this instance. Useful for clearing data when a user logs out. */
-    reset: () => {
+    reset: ({ config }) => {
+      const mixpanel = resolveMixpanel(config);
       mixpanel.reset();
     },
     /* Custom methods to add .alias call */
@@ -164,10 +118,12 @@ function mixpanelPlugin(pluginConfig = {}) {
        * @param  {string} [original] - The current identifier being used for this user.
        */
       alias(alias, original) {
+        const mixpanel = resolveMixpanel(pluginConfig);
         mixpanel.alias(alias, original);
       },
     },
   };
+  return plugin;
 }
 
 export default mixpanelPlugin;

--- a/packages/analytics-plugin-mixpanel/src/browser.js
+++ b/packages/analytics-plugin-mixpanel/src/browser.js
@@ -146,6 +146,9 @@ function mixpanelPlugin(pluginConfig = {}) {
         const mixpanel = resolveMixpanel(pluginConfig);
         mixpanel.alias(alias, original);
       },
+      getMixpanel() {
+        return resolveMixpanel(pluginConfig);
+      },
     },
   };
   return plugin;

--- a/packages/analytics-plugin-mixpanel/src/browser.js
+++ b/packages/analytics-plugin-mixpanel/src/browser.js
@@ -117,9 +117,7 @@ function mixpanelPlugin(pluginConfig = {}) {
     page: ({ config, payload }) => {
       const mixpanel = resolveMixpanel(config);
       const pageEvent = config.pageEvent || 'page';
-      mixpanel.track(pageEvent, {
-        search: payload.properties.search,
-      });
+      mixpanel.track(pageEvent, payload.properties);
     },
     /* https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpaneltrack */
     track: ({ config, payload }) => {

--- a/packages/analytics-plugin-mixpanel/src/browser.js
+++ b/packages/analytics-plugin-mixpanel/src/browser.js
@@ -12,6 +12,9 @@ import browserLoadMixpanel from './browserLoadMixpanel';
   *   in `initialize` step.
   *   If mixpanel instance already exists, it is updated with this config
   *   using `mixpanel.set_config()`.
+  * @property {String} [pageEvent] - Mixpanel doesn't have a 'page'
+  *   function, so we are using the `mixpanel.track()` method. Use this option
+  *   to override the event name. Defaults to `'page'`.
   */
 
 /**
@@ -109,12 +112,12 @@ function mixpanelPlugin(pluginConfig = {}) {
       }
     },
     /**
-     * Mixpanel doesn't have a "page" function, so we are using the track method by sending
-     * the path as tracked event and search parameters as properties
+     * Mixpanel doesn't have a "page" function, so we are using the track method.
      */
     page: ({ config, payload }) => {
       const mixpanel = resolveMixpanel(config);
-      mixpanel.track(payload.properties.path, {
+      const pageEvent = config.pageEvent || 'page';
+      mixpanel.track(pageEvent, {
         search: payload.properties.search,
       });
     },

--- a/packages/analytics-plugin-mixpanel/src/browserLoadMixpanel.js
+++ b/packages/analytics-plugin-mixpanel/src/browserLoadMixpanel.js
@@ -1,4 +1,24 @@
 /**
+ * Try to load mixpanel using `mixpanel-browser` package
+ *
+ * @param {*} [ctx] Context object where the mixpanel instance should be set
+ * @returns {Object|undefined} Mixpanel instance
+ */
+const loadMixpanelByImport = (ctx) => {
+  let mixpanel;
+  try {
+    mixpanel = require('mixpanel-browser');
+  } catch (er) {
+    /* noop */
+  }
+
+  if (mixpanel && ctx) {
+    ctx.mixpanel = mixpanel;
+  }
+  return mixpanel;
+};
+
+/**
  * Try to load mixpanel using initialization script
  *
  * @param {*} [ctx] Context object where the mixpanel instance should be set
@@ -105,7 +125,7 @@ const loadMixpanelByScript = (ctx = window) => {
  * @returns {Object|undefined} Mixpanel instance
  */
 const loadMixpanel = (ctx) => {
-  return loadMixpanelByScript(ctx);
+  return loadMixpanelByImport(ctx) || loadMixpanelByScript(ctx);
 };
 
-export { loadMixpanel as default, loadMixpanelByScript };
+export { loadMixpanel as default, loadMixpanelByImport, loadMixpanelByScript };

--- a/packages/analytics-plugin-mixpanel/src/browserLoadMixpanel.js
+++ b/packages/analytics-plugin-mixpanel/src/browserLoadMixpanel.js
@@ -1,0 +1,111 @@
+/**
+ * Try to load mixpanel using initialization script
+ *
+ * @param {*} [ctx] Context object where the mixpanel instance should be set
+ * @returns {Object|undefined} Mixpanel instance
+ */
+const loadMixpanelByScript = (ctx = window) => {
+  // Load mixpanel library
+  (function(c, a) {
+    if (!a.__SV) {
+      var b = ctx;
+      try {
+        var d,
+          m,
+          j,
+          k = b.location,
+          f = k.hash;
+        d = function(a, b) {
+          return (m = a.match(RegExp(b + "=([^&]*)"))) ? m[1] : null;
+        };
+        f &&
+          d(f, "state") &&
+          ((j = JSON.parse(decodeURIComponent(d(f, "state")))),
+          "mpeditor" === j.action &&
+            (b.sessionStorage.setItem("_mpcehash", f),
+            history.replaceState(
+              j.desiredHash || "",
+              c.title,
+              k.pathname + k.search
+            )));
+      } catch (n) {}
+      var l, h;
+      ctx.mixpanel = a;
+      a._i = [];
+      a.init = function(b, d, g) {
+        function c(b, i) {
+          var a = i.split(".");
+          2 == a.length && ((b = b[a[0]]), (i = a[1]));
+          b[i] = function() {
+            b.push([i].concat(Array.prototype.slice.call(arguments, 0)));
+          };
+        }
+        var e = a;
+        "undefined" !== typeof g ? (e = a[g] = []) : (g = "mixpanel");
+        e.people = e.people || [];
+        e.toString = function(b) {
+          var a = "mixpanel";
+          "mixpanel" !== g && (a += "." + g);
+          b || (a += " (stub)");
+          return a;
+        };
+        e.people.toString = function() {
+          return e.toString(1) + ".people (stub)";
+        };
+        l = "disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(
+          " "
+        );
+        for (h = 0; h < l.length; h++) c(e, l[h]);
+        var f = "set set_once union unset remove delete".split(" ");
+        e.get_group = function() {
+          function a(c) {
+            b[c] = function() {
+              call2_args = arguments;
+              call2 = [c].concat(Array.prototype.slice.call(call2_args, 0));
+              e.push([d, call2]);
+            };
+          }
+          for (
+            var b = {},
+              d = ["get_group"].concat(
+                Array.prototype.slice.call(arguments, 0)
+              ),
+              c = 0;
+            c < f.length;
+            c++
+          )
+            a(f[c]);
+          return b;
+        };
+        a._i.push([b, d, g]);
+      };
+      a.__SV = 1.2;
+      b = c.createElement("script");
+      b.type = "text/javascript";
+      b.async = !0;
+      b.src =
+        "undefined" !== typeof ctx.MIXPANEL_CUSTOM_LIB_URL
+          ? ctx.MIXPANEL_CUSTOM_LIB_URL
+          : "file:" === c.location.protocol &&
+            "//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)
+          ? "https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js"
+          : "//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";
+      d = c.getElementsByTagName("script")[0];
+      d.parentNode.insertBefore(b, d);
+    }
+  })(document, ctx.mixpanel || []);
+
+  return ctx.mixpanel;
+};
+
+/**
+ * Try to load mixpanel using either npm package import or initialization script
+ *
+ * @param {*} [ctx] Context object where the mixpanel instance should be set
+ * @returns {Object|undefined} Mixpanel instance
+ */
+const loadMixpanel = (ctx) => {
+  return loadMixpanelByScript(ctx);
+};
+
+export { loadMixpanel as default, loadMixpanelByScript };


### PR DESCRIPTION
Hi, here's a bunch of suggestions / improvements:

**Background**

When I was using Mixpanel with `analytics` package, I wanted to use `@analytics/mixpanel` package with it to simplify the setup.

While it did the job, I had to disable 2 hooks on `@analytics/mixpanel` simply because the implementation was too opinionated.

The issue was that `@analytics/mixpanel` loads Mixpanel strictly via a browser script, while we were using the `mixpanel-browser` package. To work around that, we had to assign the `mixpanel` instance to `window`.

Another issue with the initialization was that it did not allow any mixpanel config to be passed through. Although we could use `mixpanel.set_config`, we needed to set the `api_host` from the very beginning. If we used `mixpanel.set_config`, this was not guaranteed.

Other issue was that the `page` hook implementation was too limited (only `search` property allowed), and having event name based on current path is an issue in downstream analytics, because you don't have a way to identify all `page` events (better solution is to have a constant event name, like `'page'`, and pass the current path as an event attribute.

So this MR introduces changes that to fix those issues, plus improve usability around specifying how the mixpanel instance should be loaded.

For individual changes, see the commits.

**Changes**

- Add `pageEvent` mixpanel plugin config option
  - The page event name can be changed with a `pageEvent` plugin config value.
  - Allows to specify the name of the event that's tracked when `page` hook is called. Defaults to `'page'`
- Refactor `page` hook to pass all properties to `mixpanel.track`
- Try to load mixpanel from 'mixpanel-browser' if available
  - If 'mixpanel-browser' npm package is installed, the @analytics/mixpanel
plugin will try to use that if a mixpanel instance doesn't exist yet, otherwise it uses the load script as before
- Move the mixpanel load script to separate file
  - Modify the load script to be able to specify which context object the mixpanel instance should be be loaded to. Defaults to `window` (same as before).
- Add `mixpanel` mixpanel plugin config option
  - To be able to pass a mixpanel instance directly to
mixpanel plugin instead of always fetching and initializing it from mixpanel CDN
- Add `context` mixpanel plugin config option


- Add `context` mixpanel plugin config option that specifies the context
that's passed the refactored load script
- Update hooks to get mixpanel instance from resolveMixpanel function
instead of from `window`. This decouples the use of mixpanel instance
from the window object
- Add `config` mixpanel plugin config option to pass Mixpanel config
  - The config is passed to `mixpanel.init` if the instance needs to be
instantiated, or to `mixpanel.set_config` if the instance already exists
- Add 'getMixpanel' plugin method that returns current mixpanel instance, instead of accessing the instance via `window`