### PR TITLE
Mixpanel types

### DIFF
--- a/jsdoc.config.js
+++ b/jsdoc.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: [
+    'jsdoc-plugin-intersection'
+  ],
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "dox": "^0.9.0",
     "indent-string": "^4.0.0",
     "jsdoc": "^3.6.3",
+    "jsdoc-plugin-intersection": "^1.0.4",
     "lerna": "^3.10.7",
     "markdown-magic": "^0.1.25",
     "mkdirp": "^0.5.1",

--- a/packages/analytics-core/package.json
+++ b/packages/analytics-core/package.json
@@ -26,7 +26,7 @@
     "test:watch": "ava -v --watch",
     "clean": "rimraf lib dist && mkdirp lib dist",
     "prebuild": "npm run clean && npm run types",
-    "types": "../../node_modules/.bin/jsdoc -t ../../node_modules/tsd-jsdoc/dist -r ./src/ -d temp-types && node scripts/types.js",
+    "types": "../../node_modules/.bin/jsdoc -c ../../jsdoc.config.js -t ../../node_modules/tsd-jsdoc/dist -r ./src/ -d temp-types && node scripts/types.js",
     "build": "node ../../scripts/build/index.js",
     "postbuild": "npm run minify-dist && node ./scripts/postbuild.js",
     "watch": "node ../../scripts/build/_watch.js",

--- a/packages/analytics-core/scripts/types.js
+++ b/packages/analytics-core/scripts/types.js
@@ -11,17 +11,55 @@ const content = fs.readFileSync(TYPES_PATH, 'utf-8')
 const typesFromJsDocs = content
   // Remove declares
   .replace(/^declare\s/gm, '')
-  // Export analytics instance
-  .replace(/type AnalyticsInstance =/gm, 'export type AnalyticsInstance =')
+  // Export user-facing types (and where possible, convert objects to interface so they can be extended)
+  .replace(/type AnalyticsInstance =/gm, 'export interface AnalyticsInstance ')
+  .replace(/type AnalyticsInstanceConfig =/gm, 'export interface AnalyticsInstanceConfig ')
+  .replace(/type (\w+)Payload =/gm, match => `export ${match}`)
+  // Exported so user doesn't have to do ReturnType to get them
+  .replace(/type DetachListeners =/gm, 'export type DetachListeners =')
+
+  // Convert following types to generics to be able to pass payload type throught them
+  // Export hooks and convert them to generics accepting payload type
+  .replace(
+    /type (\w+)Hook =(.*)Context/gm,
+    (_, typeName, argsDefStart) => `export type ${typeName}Hook<T = ${typeName}Payload> =${argsDefStart}Context<T>`,
+  )
+  // Convert contexts to generics accepting payload type
+  .replace(
+    /type (\w+)Context =(.*)ContextProps(\W)/gm,
+    (_, typeName, typeDefStart, typeDefEnd) => `type ${typeName}Context<T = ${typeName}Payload> =${typeDefStart}ContextProps<T>${typeDefEnd}`,
+  )
+  // Convert context props types to generics accepting payload type
+  .replace(
+    /type (\w+)ContextProps =((.|\s)*?)payload: \w+/gm,
+    (_, typeName, typeDefStart) => `type ${typeName}ContextProps<T = ${typeName}Payload> =${typeDefStart}payload: T`,
+  )
+
+  // Rename following types so we can set generics in their place
+  .replace(/type AnalyticsPlugin = /gm, 'interface AnalyticsPluginBase ')
+  .replace(/type PageData = /gm, 'interface PageDataBase ')
   // Make promises return void
   .replace(/\@returns \{Promise\}/gm, '@returns {Promise<void>}')
   .replace(/=> Promise;/gm, '=> Promise<any>;')
-  // Fix plugin interface
-  .replace(/plugins\?: object\[\]/gm, 'plugins?: Array<AnalyticsPlugin>')
+  // Convert unions ('|') to joins ('&').
+  // Joins are used for modular JSDOC typedefs that support intellisense in VS Code.
+  // 'jsdoc' cannot parse joins, so they are temporarily transpiled to unions by 'jsdoc-plugin-intersection'.
+  .replace(/ \| /gm, ' & ')
+
+// Make types extensible
+const typeExtensions = `
+
+  export type PageData<T extends string = string> = PageDataBase & Record<T, unknown>;
+  export type AnalyticsPlugin<T extends string = string> = AnalyticsPluginBase & string extends T
+    ? Record<string, unknown>
+    : Record<T, Hook> & Record<string, unknown>;
+`;
 
 // Expose main API
 const newContent = `declare module "analytics" {
 ${indentString(typesFromJsDocs, 2)}
+${typeExtensions}
+
   export const CONSTANTS: constants;
 
   export const init: typeof analytics;

--- a/packages/analytics-core/src/events.js
+++ b/packages/analytics-core/src/events.js
@@ -106,7 +106,7 @@ export const coreEvents = [
    */
   'identifyEnd',
   /**
-   * `identifyAborted` - Fires if 'track' call is cancelled by a plugin
+   * `identifyAborted` - Fires if 'identify' call is cancelled by a plugin
    */
   'identifyAborted',
   /**

--- a/packages/analytics-core/src/middleware/identify.js
+++ b/packages/analytics-core/src/middleware/identify.js
@@ -29,7 +29,8 @@ export default function identifyMiddleware(instance) {
       const currentTraits = getItem(USER_TRAITS) || {}
 
       if (currentId && (currentId !== userId)) {
-        store.dispatch({
+        /** @type {UserIdChangedPayload} */
+        const userIdChangedPayload = {
           type: EVENTS.userIdChanged,
           old: {
             userId: currentId,
@@ -40,7 +41,8 @@ export default function identifyMiddleware(instance) {
             traits
           },
           options: options,
-        })
+        };
+        store.dispatch(userIdChangedPayload);
       }
 
       /* Save user id */

--- a/packages/analytics-core/src/middleware/plugins/index.js
+++ b/packages/analytics-core/src/middleware/plugins/index.js
@@ -30,6 +30,7 @@ export default function pluginMiddleware(instance, getPlugins, systemEvents) {
         acc[curr] = allPlugins[curr]
         return acc
       }, {})
+      /** @type {InitializePayload} */
       const initializeAction = {
         type: EVENTS.initializeStart,
         plugins: action.plugins
@@ -82,11 +83,13 @@ export default function pluginMiddleware(instance, getPlugins, systemEvents) {
         // setTimeout to ensure runs after 'page'
         setTimeout(() => {
           if (pluginsArray.length === allCalls.length) {
-            store.dispatch({
+            /** @type {ReadyPayload} */
+            const readyPayload = {
               type: EVENTS.ready,
               plugins: completed,
               failed: failed
-            })
+            };
+            store.dispatch(readyPayload);
           }
         }, 0)
       })

--- a/packages/analytics-core/src/middleware/storage.js
+++ b/packages/analytics-core/src/middleware/storage.js
@@ -19,22 +19,24 @@ export default function storageMiddleware(storage) {
   }
 }
 
-export const setItem = (key, value, opts) => {
+export const setItem = (key, value, options) => {
+  /** @type {SetItemPayload} */
   return {
     type: EVENTS.setItemStart,
     timestamp: timestamp(),
-    key: key,
-    value: value,
-    options: opts,
+    key,
+    value,
+    options,
   }
 }
 
-export const removeItem = (key, opts) => {
+export const removeItem = (key, options) => {
+  /** @type {RemoveItemPayload} */
   return {
     type: EVENTS.removeItemStart,
     timestamp: timestamp(),
-    key: key,
-    options: opts,
+    key,
+    options,
   }
 }
 

--- a/packages/analytics-core/src/modules/plugins.js
+++ b/packages/analytics-core/src/modules/plugins.js
@@ -97,6 +97,7 @@ export default function createReducer(getPlugins) {
 }
 
 export const enablePlugin = (name, callback) => {
+  /** @type {EnablePluginPayload} */
   return {
     type: EVENTS.enablePlugin,
     name: name,
@@ -108,6 +109,7 @@ export const enablePlugin = (name, callback) => {
 }
 
 export const disablePlugin = (name, callback) => {
+  /** @type {EnablePluginPayload} */
   return {
     type: EVENTS.disablePlugin,
     name: name,

--- a/packages/analytics-core/src/pluginTypeDef.js
+++ b/packages/analytics-core/src/pluginTypeDef.js
@@ -1,12 +1,500 @@
+//////////////////
+// Plugins
+//////////////////
+
 /**
-  * @typedef {Object} AnalyticsPlugin
-  * @property {string} name - Name of plugin
-  * @property {Object} [EVENTS] - exposed events of plugin
-  * @property {Object} [config] - Configuration of plugin
-  * @property {function} [initialize] - Load analytics scripts method
-  * @property {function} [page] - Page visit tracking method
-  * @property {function} [track] - Custom event tracking method
-  * @property {function} [identify] - User identify method
-  * @property {function} [loaded] - Function to determine if analytics script loaded
-  * @property {function} [ready] - Fire function when plugin ready
+ * @typedef {Object} AnalyticsPlugin
+ * @property {string} name Name of plugin
+ * @property {Object} [EVENTS] Exposed events of plugin
+ * @property {Object} [config] Configuration of plugin
+ * @property {Hook} [loaded] - Function to determine if analytics script loaded
+ * @property {BootstrapHook} [bootstrap] Fires when analytics library starts up
+ * @property {ParamsHook} [params] Fires when analytics parses URL parameters
+ * @property {CampaignHook} [campaign] Fires if params contain "utm" parameters
+ * @property {InitializeHook} [initializeStart] Fires before 'initialize', allows for plugins to cancel loading of other plugins
+ * @property {InitializeHook} [initialize] Fires when analytics loads plugins
+ * @property {InitializeHook} [initializeEnd] Fires after initialize, allows for plugins to run logic after initialization methods run
+ * @property {ReadyHook} [ready] Fires when all analytic providers are fully loaded. This waits for 'initialize' and 'loaded' to return true
+ * @property {ResetHook} [resetStart] Fires if analytic.reset() is called.
+ * @property {ResetHook} [reset] Fires if analytic.reset() is called.
+ * @property {ResetHook} [resetEnd] Fires after analytic.reset() is called.
+ * @property {PageHook} [pageStart] Fires before 'page' events fire.
+ * @property {PageHook} [page] Core analytics hook for page views.
+ * @property {PageHook} [pageEnd] Fires after all registered 'page' methods fire.
+ * @property {PageHook} [pageAborted] Fires if 'page' call is cancelled by a plugin
+ * @property {TrackHook} [trackStart] Called before the 'track' events fires.
+ * @property {TrackHook} [track] Core analytics hook for event tracking.
+ * @property {TrackHook} [trackEnd] Fires after all registered 'track' events fire from plugins.
+ * @property {TrackHook} [trackAborted] Fires if 'track' call is cancelled by a plugin
+ * @property {IdentifyHook} [identifyStart] Called before the 'identify' events fires.
+ * @property {IdentifyHook} [identify] Core analytics hook for user identification.
+ * @property {IdentifyHook} [identifyEnd] Fires after all registered 'identify' events fire from plugins.
+ * @property {IdentifyHook} [identifyAborted] Fires if 'identify' call is cancelled by a plugin
+ * @property {UserIdChangedHook} [userIdChanged] Fires when a user id is updated
+ * @property {RegisterPluginsHook} [registerPlugins] Fires when analytics is registering plugins
+ * @property {EnablePluginHook} [enablePlugin] Fires when 'analytics.enablePlugin()' is called
+ * @property {EnablePluginHook} [disablePlugin] Fires when 'analytics.disablePlugin()' is called
+ * @property {EnablePluginHook} [loadPlugin] Fires when 'analytics.loadPlugin()' is called
+ * @property {EmptyHook} [online] Fires when browser network goes online.
+ * @property {EmptyHook} [offline] Fires when browser network goes offline.
+ * @property {SetItemHook} [setItemStart] Fires when analytics.storage.setItem is initialized.
+ * @property {SetItemHook} [setItem] Fires when analytics.storage.setItem is called.
+ * @property {SetItemHook} [setItemEnd] Fires when setItem storage is complete.
+ * @property {SetItemHook} [setItemAborted] Fires when setItem storage is cancelled by a plugin.
+ * @property {RemoveItemHook} [removeItemStart] Fires when analytics.storage.removeItem is initialized.
+ * @property {RemoveItemHook} [removeItem] Fires when analytics.storage.removeItem is called.
+ * @property {RemoveItemHook} [removeItemEnd] Fires when removeItem storage is complete.
+ * @property {RemoveItemHook} [removeItemAborted] Fires when removeItem storage is cancelled by a plugin.
+ */
+
+/**
+ * @typedef {Object} PluginState State of a plugin
+ * @property {Object} [config] Configuration of plugin
+ * @property {Boolean} enabled Whether plugin is enabled
+ * @property {Boolean} initialized Whether plugin is initialized
+ * @property {Boolean} loaded Whether plugin is loaded
+ */
+
+/**
+  * @typedef {Function} Abort
+  * @returns  {void}
   */
+
+//////////////////
+// Hooks
+//////////////////
+
+// Hooks - Generic
+
+/**
+ * @typedef {Object} PayloadBase
+ * @property {String} type - Event type
+ */
+
+/**
+ * @typedef {PayloadBase} EmptyPayload
+ */
+
+/**
+ * @typedef {Object} EmptyContextProps
+ * @property {PayloadBase} payload Empty payload in hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & EmptyContextProps} EmptyContext Context with empty payload passed to a hook
+ */
+
+ /**
+ * @typedef {Function} EmptyHook
+ * @param  {EmptyContext} context Context with empty payload passed to a base hook
+ */
+
+/**
+  * @typedef {Object} HookContextBase Base of the context passed to a generic plugin hook
+  * @property  {string} hello Name of current plugin
+  * @property  {AnalyticsInstance} instance Analytics instance
+  * @property  {Object} [config] Configuration of plugin
+  */
+
+/**
+  * @typedef {Object} HookContextPropsCommon
+  * @property  {Object.<string, PluginState>} plugins Name of plugins(s) to disable
+  * @property  {Abort} abort Name of plugins(s) to disable
+  */
+
+/**
+  * @typedef {HookContextBase & HookContextPropsCommon} HookContextCommon
+  */
+
+/**
+ * @typedef {PayloadBase} HookPayload Payload in any hook
+ */
+
+/**
+  * @typedef {Object} HookContextProps
+  * @property {Object} payload Payload in any hook
+  */
+
+/**
+  * @typedef {HookContextCommon & HookContextProps} HookContext Context passed to a generic plugin hook
+  * @property  {Object} payload Name of plugins(s) to disable
+  */
+
+/**
+ * @typedef {Function} Hook Generic hook on the AnalyticsPlugin object.
+ * @param  {HookContext} context Context passed to a plugin hook
+ */
+
+// Hooks - Bootstrap
+
+/**
+ * @typedef {AnalyticsPlugin} BootstrapPayload Payload in any hook
+ */
+
+/**
+ * @typedef {Object} BootstrapContextProps Context passed to bootstrap hook
+ * @property {BootstrapPayload} payload Analytics plugin
+ */
+
+ /**
+ * @typedef {HookContextCommon & BootstrapContextProps} BootstrapContext Context passed to bootstrap hook
+ */
+
+ /**
+ * @typedef {Function} BootstrapHook
+ * @param  {BootstrapContext} context Context passed to bootstrap hook
+ * @returns  {void}
+ */
+
+// Hooks - Params
+
+/**
+ * @typedef {Object} ParamsPayloadProps Payload in params hook
+ * @property {Object.<string, string>} raw Raw search params
+ * @property {Object.<string, string>} props Props search params
+ * @property {Object.<string, string>} traits Traits search params
+ * @property {String} [userId] User ID.
+ */
+
+ /**
+ * @typedef {PayloadBase & CampaignPayloadProps & ParamsPayloadProps} ParamsPayload Payload in params hook
+ */
+
+ /**
+ * @typedef {Object} ParamsContextProps
+ * @property {ParamsPayload} payload Payload in params hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & ParamsContextProps} ParamsContext Context passed to params hook
+ */
+
+ /**
+ * @typedef {Function} ParamsHook
+ * @param  {ParamsContext} context Context passed to params hook
+ */
+
+// Hooks - Campaign
+
+/**
+ * @typedef {Object} CampaignPayloadProps
+ * @property {Object.<string, string>} campaign UTM search params
+ */
+
+ /**
+ * @typedef {PayloadBase & CampaignPayloadProps} CampaignPayload Payload in campaign hook
+ */
+
+ /**
+ * @typedef {Object} CampaignContextProps
+ * @property {CampaignPayload} payload Payload in campaign hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & CampaignContextProps} CampaignContext Context passed to campaign hook
+ */
+
+ /**
+ * @typedef {Function} CampaignHook
+ * @param  {CampaignContext} context Context passed to campaign hook
+ */
+
+// Hooks - Initialize
+
+/**
+ * @typedef {Object} InitializePayloadProps
+ * @property {Array.<string>} plugins Names of plugins
+ */
+
+ /**
+ * @typedef {PayloadBase & InitializePayloadProps} InitializePayload Payload in initialize hook
+ */
+
+ /**
+ * @typedef {Object} InitializeContextProps
+ * @property {InitializePayload} payload Payload in initialize hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & InitializeContextProps} InitializeContext Context passed to initialize hook
+ */
+
+ /**
+ * @typedef {Function} InitializeHook
+ * @param  {InitializeContext} context Context passed to initialize hook
+ */
+
+// Hooks - Ready
+
+/**
+ * @typedef {Object} ReadyPayloadProps
+ * @property {Array.<string>} failed Names of failed plugins
+ */
+
+ /**
+ * @typedef {PayloadBase & InitializePayloadProps & ReadyPayloadProps} ReadyPayload Payload in ready hook
+ */
+
+ /**
+ * @typedef {Object} ReadyContextProps
+ * @property {ReadyPayload} payload Payload in ready hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & ReadyContextProps} ReadyContext Context passed to ready hook
+ */
+
+/**
+ * @typedef {Function} ReadyHook
+ * @param  {ReadyContext} context Context passed to ready hook
+ */
+
+// Hooks - Reset
+
+/**
+ * @typedef {Object} ResetPayloadProps
+ * @property {Number} timestamp
+ * @property {Function} callback
+ */
+
+ /**
+ * @typedef {PayloadBase & ResetPayloadProps} ResetPayload Payload in reset hook
+ */
+
+ /**
+ * @typedef {Object} ResetContextProps
+ * @property {ResetPayload} payload Payload in reset hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & ResetContextProps} ResetContext Context passed to reset hook
+ */
+
+ /**
+ * @typedef {Function} ResetHook
+ * @param  {ResetContext} context Context passed to reset hook
+ */
+
+// Hooks - Page
+
+/**
+ * @typedef {Object} PagePayloadProps
+ * @property {String} anonymousId
+ * @property {String} userId
+ * @property {ResetPayloadProps} meta
+ * @property {Object} properties
+ * @property {Object} options
+ */
+
+ /**
+ * @typedef {PayloadBase & PagePayloadProps} PagePayload Payload in page hook
+ */
+
+ /**
+ * @typedef {Object} PageContextProps
+ * @property {PagePayload} payload Payload in page hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & PageContextProps} PageContext Context passed to page hook
+ */
+
+ /**
+ * @typedef {Function} PageHook
+ * @param  {PageContext} context Context passed to page hook
+ */
+
+// Hooks - Track
+
+/**
+ * @typedef {Object} TrackPayloadProps
+ * @property {String} anonymousId
+ * @property {String} userId
+ * @property {String} event
+ * @property {ResetPayloadProps} meta
+ * @property {Object} properties
+ * @property {Object} options
+ */
+
+ /**
+ * @typedef {PayloadBase & TrackPayloadProps} TrackPayload Payload in track hook
+ */
+
+ /**
+ * @typedef {Object} TrackContextProps
+ * @property {TrackPayload} payload Payload in track hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & TrackContextProps} TrackContext Context passed to track hook
+ */
+
+ /**
+ * @typedef {Function} TrackHook
+ * @param  {TrackContext} context Context passed to track hook
+ */
+
+// Hooks - Identify
+
+/**
+ * @typedef {Object} IdentifyPayloadProps
+ * @property {String} anonymousId
+ * @property {String} userId
+ * @property {ResetPayloadProps} meta
+ * @property {Object} traits
+ * @property {Object} options
+ */
+
+ /**
+ * @typedef {PayloadBase & IdentifyPayloadProps} IdentifyPayload Payload in identify hook
+ */
+
+ /**
+ * @typedef {Object} IdentifyContextProps
+ * @property {IdentifyPayload} payload Payload in identify hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & IdentifyContextProps} IdentifyContext Context passed to identify hook
+ */
+
+ /**
+ * @typedef {Function} IdentifyHook
+ * @param  {IdentifyContext} context Context passed to identify hook
+ */
+
+// Hooks - UserIdChanged
+
+/**
+ * @typedef {Object} UserIdChangedState
+ * @property {String} userId
+ * @property {Object} traits
+ */
+
+ /**
+ * @typedef {Object} UserIdChangedPayloadProps
+ * @property {UserIdChangedState} new
+ * @property {UserIdChangedState} old
+ * @property {Object} options
+ */
+
+ /**
+ * @typedef {PayloadBase & UserIdChangedPayloadProps} UserIdChangedPayload Payload in userIdChanged hook
+ */
+
+ /**
+ * @typedef {Object} UserIdChangedContextProps
+ * @property {UserIdChangedPayload} payload Payload in userIdChanged hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & UserIdChangedContextProps} UserIdChangedContext Context passed to userIdChanged hook
+ */
+
+ /**
+ * @typedef {Function} UserIdChangedHook
+ * @param  {UserIdChangedContext} context Context passed to userIdChanged hook
+ */
+
+// Hooks - RegisterPlugins
+
+/**
+ * @typedef {Object} RegisterPluginsPayloadProps
+ * @property {Array.<String>} plugins
+ */
+
+ /**
+ * @typedef {PayloadBase & RegisterPluginsPayloadProps} RegisterPluginsPayload Payload in RegisterPlugins hook
+ */
+
+ /**
+ * @typedef {Object} RegisterPluginsContextProps
+ * @property {RegisterPluginsPayload} payload Payload in registerPlugins hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & RegisterPluginsContextProps} RegisterPluginsContext Context passed to registerPlugins hook
+ */
+
+ /**
+ * @typedef {Function} RegisterPluginsHook
+ * @param  {RegisterPluginsContext} context Context passed to registerPlugins hook
+ */
+
+// Hooks - EnablePlugin
+
+/**
+ * @typedef {Object} EnablePluginPayloadProps
+ * @property {Function} [callback]
+ * @property {String} name
+ */
+
+ /**
+ * @typedef {PayloadBase & EnablePluginPayloadProps} EnablePluginPayload Payload in enablePlugin hook
+ */
+
+ /**
+ * @typedef {Object} EnablePluginContextProps
+ * @property {EnablePluginPayload} payload Payload in enablePlugin hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & EnablePluginContextProps} EnablePluginContext Context passed to enablePlugin hook
+ */
+
+ /**
+ * @typedef {Function} EnablePluginHook
+ * @param  {EnablePluginContext} context Context passed to enablePlugin hook
+ */
+
+// Hooks - RemoveItem
+
+/**
+ * @typedef {Object} RemoveItemPayloadProps
+ * @property {String} key
+ * @property {Number} timestamp
+ * @property {Object} [options]
+ */
+
+ /**
+ * @typedef {PayloadBase & RemoveItemPayloadProps} RemoveItemPayload Payload in removeItem hook
+ */
+
+ /**
+ * @typedef {Object} RemoveItemContextProps
+ * @property {RemoveItemPayload} payload Payload in removeItem hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & RemoveItemContextProps} RemoveItemContext Context passed to removeItem hook
+ */
+
+ /**
+ * @typedef {Function} RemoveItemHook
+ * @param  {RemoveItemContext} context Context passed to removeItem hook
+ */
+
+// Hooks - SetItem
+
+/**
+ * @typedef {Object} SetItemPayloadProps
+ * @property {*} [value]
+ */
+
+ /**
+ * @typedef {PayloadBase & RemoveItemPayloadProps & SetItemPayloadProps} SetItemPayload Payload in setItem hook
+ */
+
+ /**
+ * @typedef {Object} SetItemContextProps
+ * @property {SetItemPayload} payload Payload in setItem hook
+ */
+
+ /**
+ * @typedef {HookContextCommon & SetItemContextProps} SetItemContext Context passed to setItem hook
+ */
+
+ /**
+ * @typedef {Function} SetItemHook
+ * @param  {SetItemContext} context Context passed to setItem hook
+ */

--- a/packages/analytics-plugin-mixpanel/.gitignore
+++ b/packages/analytics-plugin-mixpanel/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+temp-types
 
 dist
 lib

--- a/packages/analytics-plugin-mixpanel/package.json
+++ b/packages/analytics-plugin-mixpanel/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "docs": "node ../analytics-cli/bin/run docs",
     "build": "node ../../scripts/build/index.js",
+    "types": "../../node_modules/.bin/jsdoc -t ../../node_modules/tsd-jsdoc/dist -r ./src/ -d temp-types && node ./scripts/types.js",
     "watch": "node ../../scripts/build/_watch.js",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
@@ -46,6 +47,9 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/DavidWells/analytics.git"
+  },
+  "dependencies": {
+    "analytics": "^0.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",

--- a/packages/analytics-plugin-mixpanel/package.json
+++ b/packages/analytics-plugin-mixpanel/package.json
@@ -50,5 +50,13 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.3.1"
+  },
+  "peerDependencies": {
+    "mixpanel-browser": "^2.0.0"
+  },
+  "peerDependenciesMeta": {   
+    "mixpanel-browser": {     
+      "optional": true   
+    }
   }
 }

--- a/packages/analytics-plugin-mixpanel/scripts/types.js
+++ b/packages/analytics-plugin-mixpanel/scripts/types.js
@@ -1,0 +1,36 @@
+// https://github.com/englercj/tsd-jsdoc/issues/64#issuecomment-462020832
+const fs = require('fs')
+const path = require('path')
+const indentString = require('indent-string')
+const mkdirp = require('mkdirp')
+
+const TYPES_PATH = path.resolve(__dirname, '../temp-types/types.d.ts')
+const OUTPUT_PATH = path.resolve(__dirname, '../lib/types.d.ts')
+const content = fs.readFileSync(TYPES_PATH, 'utf-8')
+
+const typesFromJsDocs = content
+  // Remove declares
+  .replace(/^declare\s/gm, '')
+  // Export plugin config
+  .replace(/type MixpanelPluginConfig =/gm, 'export interface MixpanelPluginConfig')
+  // Remove dummy Mixpanel interfaces
+  .replace(/type Mixpanel =.+;/gm, '')
+  .replace(/type MixpanelConfig =.+;/gm, '')
+  // Make Mixpanel config partial in places where it's assigned to something
+  .replace(/(:\s*)MixpanelConfig/gm, (_, matchStart) => `${matchStart}Partial<MixpanelConfig>`)
+
+// Expose main API
+const newContent = `
+import type { AnalyticsPlugin } from 'analytics';
+import type { Mixpanel, Config as MixpanelConfig } from 'mixpanel-browser';
+
+declare module "@analytics/mixpanel" {
+${indentString(typesFromJsDocs, 2)}
+
+  export default AnalyticsPlugin;
+}`
+
+mkdirp(path.dirname(OUTPUT_PATH), function (err) {
+  if (err) console.error(err)
+  fs.writeFileSync(OUTPUT_PATH, newContent)
+})

--- a/packages/analytics-plugin-mixpanel/src/browser.js
+++ b/packages/analytics-plugin-mixpanel/src/browser.js
@@ -1,14 +1,20 @@
 import browserLoadMixpanel from './browserLoadMixpanel';
 
+// Placeholder for Mixpanel type which is replaced postbuild
+/** @typedef {Object} Mixpanel */
+
+// Placeholder for MixpanelConfig type which is replaced postbuild
+/** @typedef {Object} MixpanelConfig */
+
 /**
   * @typedef {Object} MixpanelPluginConfig - Plugin settings for Mixpanel plugin
   * @property {String} [token] - The mixpanel token associated to a mixpanel project
-  * @property {Object} [mixpanel] - The mixpanel instance - use this
+  * @property {Mixpanel} [mixpanel] - The mixpanel instance - use this
   *   to use the plugin with a mixpanel instance instantiated elsewhere, for
   *   example when using a mixpanel npm package.
   * @property {Object} [context] - The context object where mixpanel
   *   instance is found and assigned to when instantiated. Defaults to window.
-  * @property {Object} [config] - Mixpanel config passed to `mixpanel.init()`
+  * @property {MixpanelConfig} [config] - Mixpanel config passed to `mixpanel.init()`
   *   in `initialize` step.
   *   If mixpanel instance already exists, it is updated with this config
   *   using `mixpanel.set_config()`.
@@ -20,7 +26,7 @@ import browserLoadMixpanel from './browserLoadMixpanel';
 /**
  * Get mixpanel instance from config
  * @param {MixpanelPluginConfig} config
- * @returns {Object} Mixpanel instance
+ * @returns {Mixpanel|undefined} Mixpanel instance
  */
 const resolveMixpanel = (config = {}) => {
   const { context = window, mixpanel: givenMixpanel } = config;
@@ -141,11 +147,16 @@ function mixpanelPlugin(pluginConfig = {}) {
        *
        * @param  {string} [alias] - A unique identifier that you want to use for this user in the future.
        * @param  {string} [original] - The current identifier being used for this user.
+       * @returns {void}
        */
       alias(alias, original) {
         const mixpanel = resolveMixpanel(pluginConfig);
         mixpanel.alias(alias, original);
       },
+      /**
+       * Get currect Mixpanel instance
+       * @returns {Mixpanel|undefined} The Mixpanel instance
+       */
       getMixpanel() {
         return resolveMixpanel(pluginConfig);
       },

--- a/packages/analytics-plugin-mixpanel/src/browser.js
+++ b/packages/analytics-plugin-mixpanel/src/browser.js
@@ -3,6 +3,9 @@ import browserLoadMixpanel from './browserLoadMixpanel';
 /**
   * @typedef {Object} MixpanelPluginConfig - Plugin settings for Mixpanel plugin
   * @property {String} [token] - The mixpanel token associated to a mixpanel project
+  * @property {Object} [mixpanel] - The mixpanel instance - use this
+  *   to use the plugin with a mixpanel instance instantiated elsewhere, for
+  *   example when using a mixpanel npm package.
   * @property {Object} [context] - The context object where mixpanel
   *   instance is found and assigned to when instantiated. Defaults to window.
   */
@@ -13,8 +16,8 @@ import browserLoadMixpanel from './browserLoadMixpanel';
  * @returns {Object} Mixpanel instance
  */
 const resolveMixpanel = (config = {}) => {
-  const { context = window } = config;
-  return context.mixpanel;
+  const { context = window, mixpanel: givenMixpanel } = config;
+  return givenMixpanel || context.mixpanel;
 }
 
 /**
@@ -36,6 +39,11 @@ const resolveMixpanel = (config = {}) => {
  *   context: myContext,
  * });
  *
+ * // Use existing mixpanel instance
+ * import mixpanel from 'mixpanel-browser';
+ * mixpanelPlugin({
+ *   mixpanel: mixpanel.init('abcdef123'),
+ * });
  */
 function mixpanelPlugin(pluginConfig = {}) {
   const plugin = {

--- a/packages/analytics-plugin-mixpanel/src/browser.js
+++ b/packages/analytics-plugin-mixpanel/src/browser.js
@@ -1,122 +1,70 @@
+import browserLoadMixpanel from './browserLoadMixpanel';
+
+/**
+  * @typedef {Object} MixpanelPluginConfig - Plugin settings for Mixpanel plugin
+  * @property {String} [token] - The mixpanel token associated to a mixpanel project
+  * @property {Object} [context] - The context object where mixpanel
+  *   instance is found and assigned to when instantiated. Defaults to window.
+  */
+
+/**
+ * Get mixpanel instance from config
+ * @param {MixpanelPluginConfig} config
+ * @returns {Object} Mixpanel instance
+ */
+const resolveMixpanel = (config = {}) => {
+  const { context = window } = config;
+  return context.mixpanel;
+}
+
 /**
  * Mixpanel Analytics plugin
  * @link https://getanalytics.io/plugins/mixpanel/
- * @param {object} pluginConfig - Plugin settings
- * @param {string} pluginConfig.token - The mixpanel token associated to a mixpanel project
- * @return {object} Analytics plugin
+ * @param {MixpanelPluginConfig} pluginConfig - Plugin settings
+ * @return {AnalyticsPlugin} Analytics plugin
  * @example
  *
+ * // Load Mixpanel instance to `window`
  * mixpanelPlugin({
- *   token: 'abcdef123'
- * })
+ *   token: 'abcdef123',
+ * });
+ *
+ * // Load Mixpanel instance to `context` object instead of `window`
+ * const myContext = {};
+ * mixpanelPlugin({
+ *   token: 'abcdef123',
+ *   context: myContext,
+ * });
+ *
  */
 function mixpanelPlugin(pluginConfig = {}) {
-  return {
+  const plugin = {
     NAMESPACE: "mixpanel",
     config: pluginConfig,
     /* https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelinit */
     initialize: ({ config }) => {
-      const { token } = config;
-      if (!token) {
-        throw new Error("No mixpanel token defined");
-      }
+      const {
+        token,
+        context = window,
+      } = config || {};
 
-      // NoOp if mixpanel already loaded by external source or already loaded
-      if (typeof window.mixpanel !== 'undefined') {
+      let mixpanel = resolveMixpanel(config);
+
+      const hasMixpanel = Boolean(mixpanel);
+
+      if (hasMixpanel) {
+        // NoOp if mixpanel already loaded by external source or already loaded
         return;
       }
 
-      // Load mixpanel library
-      (function(c, a) {
-        if (!a.__SV) {
-          var b = window;
-          try {
-            var d,
-              m,
-              j,
-              k = b.location,
-              f = k.hash;
-            d = function(a, b) {
-              return (m = a.match(RegExp(b + "=([^&]*)"))) ? m[1] : null;
-            };
-            f &&
-              d(f, "state") &&
-              ((j = JSON.parse(decodeURIComponent(d(f, "state")))),
-              "mpeditor" === j.action &&
-                (b.sessionStorage.setItem("_mpcehash", f),
-                history.replaceState(
-                  j.desiredHash || "",
-                  c.title,
-                  k.pathname + k.search
-                )));
-          } catch (n) {}
-          var l, h;
-          window.mixpanel = a;
-          a._i = [];
-          a.init = function(b, d, g) {
-            function c(b, i) {
-              var a = i.split(".");
-              2 == a.length && ((b = b[a[0]]), (i = a[1]));
-              b[i] = function() {
-                b.push([i].concat(Array.prototype.slice.call(arguments, 0)));
-              };
-            }
-            var e = a;
-            "undefined" !== typeof g ? (e = a[g] = []) : (g = "mixpanel");
-            e.people = e.people || [];
-            e.toString = function(b) {
-              var a = "mixpanel";
-              "mixpanel" !== g && (a += "." + g);
-              b || (a += " (stub)");
-              return a;
-            };
-            e.people.toString = function() {
-              return e.toString(1) + ".people (stub)";
-            };
-            l = "disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(
-              " "
-            );
-            for (h = 0; h < l.length; h++) c(e, l[h]);
-            var f = "set set_once union unset remove delete".split(" ");
-            e.get_group = function() {
-              function a(c) {
-                b[c] = function() {
-                  call2_args = arguments;
-                  call2 = [c].concat(Array.prototype.slice.call(call2_args, 0));
-                  e.push([d, call2]);
-                };
-              }
-              for (
-                var b = {},
-                  d = ["get_group"].concat(
-                    Array.prototype.slice.call(arguments, 0)
-                  ),
-                  c = 0;
-                c < f.length;
-                c++
-              )
-                a(f[c]);
-              return b;
-            };
-            a._i.push([b, d, g]);
-          };
-          a.__SV = 1.2;
-          b = c.createElement("script");
-          b.type = "text/javascript";
-          b.async = !0;
-          b.src =
-            "undefined" !== typeof MIXPANEL_CUSTOM_LIB_URL
-              ? MIXPANEL_CUSTOM_LIB_URL
-              : "file:" === c.location.protocol &&
-                "//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)
-              ? "https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js"
-              : "//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";
-          d = c.getElementsByTagName("script")[0];
-          d.parentNode.insertBefore(b, d);
+      if (!hasMixpanel) {
+        if (!token) {
+          throw new Error("No mixpanel token defined");
         }
-      })(document, window.mixpanel || []);
 
-      mixpanel.init(config.token, { batch_requests: true });
+        mixpanel = browserLoadMixpanel(context);
+        mixpanel.init(token, { batch_requests: true });
+      }
     },
     /**
      * Identify a visitor in mixpanel
@@ -125,8 +73,10 @@ function mixpanelPlugin(pluginConfig = {}) {
      * Mixpanel doesn't allow to set properties directly in identify, so mixpanel.people.set is
      * also called if properties are passed
      */
-    identify: ({ payload }) => {
+    identify: ({ config, payload }) => {
+      const mixpanel = resolveMixpanel(config);
       const { userId, traits } = payload;
+
       if (typeof userId === "string") {
         mixpanel.identify(userId);
       }
@@ -138,20 +88,24 @@ function mixpanelPlugin(pluginConfig = {}) {
      * Mixpanel doesn't have a "page" function, so we are using the track method by sending
      * the path as tracked event and search parameters as properties
      */
-    page: ({ payload }) => {
+    page: ({ config, payload }) => {
+      const mixpanel = resolveMixpanel(config);
       mixpanel.track(payload.properties.path, {
         search: payload.properties.search,
       });
     },
     /* https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpaneltrack */
-    track: ({ payload }) => {
+    track: ({ config, payload }) => {
+      const mixpanel = resolveMixpanel(config);
       mixpanel.track(payload.event, payload.properties);
     },
     loaded: () => {
-      return !!window.mixpanel;
+      const mixpanel = resolveMixpanel(plugin.config);
+      return !!mixpanel;
     },
     /* Clears super properties and generates a new random distinct_id for this instance. Useful for clearing data when a user logs out. */
-    reset: () => {
+    reset: ({ config }) => {
+      const mixpanel = resolveMixpanel(config);
       mixpanel.reset();
     },
     /* Custom methods to add .alias call */
@@ -164,10 +118,12 @@ function mixpanelPlugin(pluginConfig = {}) {
        * @param  {string} [original] - The current identifier being used for this user.
        */
       alias(alias, original) {
+        const mixpanel = resolveMixpanel(pluginConfig);
         mixpanel.alias(alias, original);
       },
     },
   };
+  return plugin;
 }
 
 export default mixpanelPlugin;

--- a/packages/analytics-plugin-mixpanel/src/browser.js
+++ b/packages/analytics-plugin-mixpanel/src/browser.js
@@ -146,6 +146,9 @@ function mixpanelPlugin(pluginConfig = {}) {
         const mixpanel = resolveMixpanel(pluginConfig);
         mixpanel.alias(alias, original);
       },
+      getMixpanel() {
+        return resolveMixpanel(pluginConfig);
+      },
     },
   };
   return plugin;

--- a/packages/analytics-plugin-mixpanel/src/browser.js
+++ b/packages/analytics-plugin-mixpanel/src/browser.js
@@ -117,9 +117,7 @@ function mixpanelPlugin(pluginConfig = {}) {
     page: ({ config, payload }) => {
       const mixpanel = resolveMixpanel(config);
       const pageEvent = config.pageEvent || 'page';
-      mixpanel.track(pageEvent, {
-        search: payload.properties.search,
-      });
+      mixpanel.track(pageEvent, payload.properties);
     },
     /* https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpaneltrack */
     track: ({ config, payload }) => {

--- a/packages/analytics-plugin-mixpanel/src/browser.js
+++ b/packages/analytics-plugin-mixpanel/src/browser.js
@@ -12,6 +12,9 @@ import browserLoadMixpanel from './browserLoadMixpanel';
   *   in `initialize` step.
   *   If mixpanel instance already exists, it is updated with this config
   *   using `mixpanel.set_config()`.
+  * @property {String} [pageEvent] - Mixpanel doesn't have a 'page'
+  *   function, so we are using the `mixpanel.track()` method. Use this option
+  *   to override the event name. Defaults to `'page'`.
   */
 
 /**
@@ -109,12 +112,12 @@ function mixpanelPlugin(pluginConfig = {}) {
       }
     },
     /**
-     * Mixpanel doesn't have a "page" function, so we are using the track method by sending
-     * the path as tracked event and search parameters as properties
+     * Mixpanel doesn't have a "page" function, so we are using the track method.
      */
     page: ({ config, payload }) => {
       const mixpanel = resolveMixpanel(config);
-      mixpanel.track(payload.properties.path, {
+      const pageEvent = config.pageEvent || 'page';
+      mixpanel.track(pageEvent, {
         search: payload.properties.search,
       });
     },

--- a/packages/analytics-plugin-mixpanel/src/browserLoadMixpanel.js
+++ b/packages/analytics-plugin-mixpanel/src/browserLoadMixpanel.js
@@ -1,4 +1,24 @@
 /**
+ * Try to load mixpanel using `mixpanel-browser` package
+ *
+ * @param {*} [ctx] Context object where the mixpanel instance should be set
+ * @returns {Object|undefined} Mixpanel instance
+ */
+const loadMixpanelByImport = (ctx) => {
+  let mixpanel;
+  try {
+    mixpanel = require('mixpanel-browser');
+  } catch (er) {
+    /* noop */
+  }
+
+  if (mixpanel && ctx) {
+    ctx.mixpanel = mixpanel;
+  }
+  return mixpanel;
+};
+
+/**
  * Try to load mixpanel using initialization script
  *
  * @param {*} [ctx] Context object where the mixpanel instance should be set
@@ -105,7 +125,7 @@ const loadMixpanelByScript = (ctx = window) => {
  * @returns {Object|undefined} Mixpanel instance
  */
 const loadMixpanel = (ctx) => {
-  return loadMixpanelByScript(ctx);
+  return loadMixpanelByImport(ctx) || loadMixpanelByScript(ctx);
 };
 
-export { loadMixpanel as default, loadMixpanelByScript };
+export { loadMixpanel as default, loadMixpanelByImport, loadMixpanelByScript };

--- a/packages/analytics-plugin-mixpanel/src/browserLoadMixpanel.js
+++ b/packages/analytics-plugin-mixpanel/src/browserLoadMixpanel.js
@@ -1,0 +1,111 @@
+/**
+ * Try to load mixpanel using initialization script
+ *
+ * @param {*} [ctx] Context object where the mixpanel instance should be set
+ * @returns {Object|undefined} Mixpanel instance
+ */
+const loadMixpanelByScript = (ctx = window) => {
+  // Load mixpanel library
+  (function(c, a) {
+    if (!a.__SV) {
+      var b = ctx;
+      try {
+        var d,
+          m,
+          j,
+          k = b.location,
+          f = k.hash;
+        d = function(a, b) {
+          return (m = a.match(RegExp(b + "=([^&]*)"))) ? m[1] : null;
+        };
+        f &&
+          d(f, "state") &&
+          ((j = JSON.parse(decodeURIComponent(d(f, "state")))),
+          "mpeditor" === j.action &&
+            (b.sessionStorage.setItem("_mpcehash", f),
+            history.replaceState(
+              j.desiredHash || "",
+              c.title,
+              k.pathname + k.search
+            )));
+      } catch (n) {}
+      var l, h;
+      ctx.mixpanel = a;
+      a._i = [];
+      a.init = function(b, d, g) {
+        function c(b, i) {
+          var a = i.split(".");
+          2 == a.length && ((b = b[a[0]]), (i = a[1]));
+          b[i] = function() {
+            b.push([i].concat(Array.prototype.slice.call(arguments, 0)));
+          };
+        }
+        var e = a;
+        "undefined" !== typeof g ? (e = a[g] = []) : (g = "mixpanel");
+        e.people = e.people || [];
+        e.toString = function(b) {
+          var a = "mixpanel";
+          "mixpanel" !== g && (a += "." + g);
+          b || (a += " (stub)");
+          return a;
+        };
+        e.people.toString = function() {
+          return e.toString(1) + ".people (stub)";
+        };
+        l = "disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(
+          " "
+        );
+        for (h = 0; h < l.length; h++) c(e, l[h]);
+        var f = "set set_once union unset remove delete".split(" ");
+        e.get_group = function() {
+          function a(c) {
+            b[c] = function() {
+              call2_args = arguments;
+              call2 = [c].concat(Array.prototype.slice.call(call2_args, 0));
+              e.push([d, call2]);
+            };
+          }
+          for (
+            var b = {},
+              d = ["get_group"].concat(
+                Array.prototype.slice.call(arguments, 0)
+              ),
+              c = 0;
+            c < f.length;
+            c++
+          )
+            a(f[c]);
+          return b;
+        };
+        a._i.push([b, d, g]);
+      };
+      a.__SV = 1.2;
+      b = c.createElement("script");
+      b.type = "text/javascript";
+      b.async = !0;
+      b.src =
+        "undefined" !== typeof ctx.MIXPANEL_CUSTOM_LIB_URL
+          ? ctx.MIXPANEL_CUSTOM_LIB_URL
+          : "file:" === c.location.protocol &&
+            "//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)
+          ? "https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js"
+          : "//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";
+      d = c.getElementsByTagName("script")[0];
+      d.parentNode.insertBefore(b, d);
+    }
+  })(document, ctx.mixpanel || []);
+
+  return ctx.mixpanel;
+};
+
+/**
+ * Try to load mixpanel using either npm package import or initialization script
+ *
+ * @param {*} [ctx] Context object where the mixpanel instance should be set
+ * @returns {Object|undefined} Mixpanel instance
+ */
+const loadMixpanel = (ctx) => {
+  return loadMixpanelByScript(ctx);
+};
+
+export { loadMixpanel as default, loadMixpanelByScript };

--- a/packages/analytics-plugin-mixpanel/src/browserLoadMixpanel.js
+++ b/packages/analytics-plugin-mixpanel/src/browserLoadMixpanel.js
@@ -2,7 +2,7 @@
  * Try to load mixpanel using `mixpanel-browser` package
  *
  * @param {*} [ctx] Context object where the mixpanel instance should be set
- * @returns {Object|undefined} Mixpanel instance
+ * @returns {Mixpanel|undefined} Mixpanel instance
  */
 const loadMixpanelByImport = (ctx) => {
   let mixpanel;
@@ -22,7 +22,7 @@ const loadMixpanelByImport = (ctx) => {
  * Try to load mixpanel using initialization script
  *
  * @param {*} [ctx] Context object where the mixpanel instance should be set
- * @returns {Object|undefined} Mixpanel instance
+ * @returns {Mixpanel|undefined} Mixpanel instance
  */
 const loadMixpanelByScript = (ctx = window) => {
   // Load mixpanel library
@@ -122,7 +122,7 @@ const loadMixpanelByScript = (ctx = window) => {
  * Try to load mixpanel using either npm package import or initialization script
  *
  * @param {*} [ctx] Context object where the mixpanel instance should be set
- * @returns {Object|undefined} Mixpanel instance
+ * @returns {Mixpanel|undefined} Mixpanel instance
  */
 const loadMixpanel = (ctx) => {
   return loadMixpanelByImport(ctx) || loadMixpanelByScript(ctx);


### PR DESCRIPTION
**Background**

As a TypeScript user working with the `@analytics/mixpanel` plugin, I want to have the plugin (and primarily the plugin config) covered by TypeScript

After https://github.com/DavidWells/analytics/pull/114, adding TypeScript support is trivial as the plugin definition can be reused.

**Changes**

- Add type annotations to types and functions in `@analytics/mixpanel`
- Add `./scripts/types` script similar to one in `@analytics/core`.
  - The script post-processes the generated `types.d.ts` to export plugin config and plugin interfaces.
- Add `analytics` as a dependency so types in `types.d.ts` can import the types exposed in https://github.com/DavidWells/analytics/pull/114
- Add `'types'` npm command to `@analytics/mixpanel`
- Add `'temp-types'` to `.gitignore`

Blocked by https://github.com/DavidWells/analytics/pull/114 and https://github.com/DavidWells/analytics/pull/115