### PR TITLE
feat(google-tag-manager): allow customScriptSrc

### DIFF
--- a/packages/analytics-plugin-google-tag-manager/README.md
+++ b/packages/analytics-plugin-google-tag-manager/README.md
@@ -82,8 +82,8 @@ The `@analytics/google-tag-manager` package works in [the browser](#browser-usag
 
 The Google Tag Manager client side browser plugin works with these analytic api methods:
 
-- **[analytics.page](https://getanalytics.io/api/#analyticspage)** - Sends page views into Google Tag Manager 
-- **[analytics.track](https://getanalytics.io/api/#analyticstrack)** - Track custom events and send to Google Tag Manager 
+- **[analytics.page](https://getanalytics.io/api/#analyticspage)** - Sends page views into Google Tag Manager
+- **[analytics.track](https://getanalytics.io/api/#analyticstrack)** - Track custom events and send to Google Tag Manager
 
 ### Browser API
 
@@ -108,7 +108,7 @@ const analytics = Analytics({
 |:---------------------------|:-----------|
 | `containerId` <br/>**required** - string| The Container ID uniquely identifies the GTM Container. |
 | `dataLayerName` <br/>_optional_ - string| The optional name for dataLayer-object. Defaults to dataLayer. |
-
+| `customScriptSrc` <br/>_optional_ - string| Load Google Tag Manager script from a custom source |
 
 ## Additional examples
 

--- a/packages/analytics-plugin-google-tag-manager/src/browser.js
+++ b/packages/analytics-plugin-google-tag-manager/src/browser.js
@@ -15,6 +15,7 @@ let initializedDataLayerName;
  * @param {object} pluginConfig - Plugin settings
  * @param {string} pluginConfig.containerId - The Container ID uniquely identifies the GTM Container.
  * @param {string} [pluginConfig.dataLayerName=dataLayer] - The optional name for dataLayer-object. Defaults to dataLayer.
+ * @param {string} [pluginConfig.customScriptSrc] - Load Google Tag Manager script from a custom source
  * @return {object} Analytics plugin
  * @example
  *
@@ -30,11 +31,14 @@ function googleTagManager(pluginConfig = {}) {
       ...config,
       ...pluginConfig
     },
-    initialize: ({ config }) => {
+    initialize: ({ config, customScriptSrc }) => {
       const { containerId, dataLayerName } = config
       if (!containerId) {
         throw new Error('No google tag manager containerId defined')
       }
+
+      const scriptSrc = customScriptSrc || 'https://www.googletagmanager.com/gtm.js';
+
       if (!scriptLoaded(containerId)) {
         /* eslint-disable */
         (function(w, d, s, l, i) {
@@ -42,7 +46,7 @@ function googleTagManager(pluginConfig = {}) {
           w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
           var f = d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
           j.async = true;
-          j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+          j.src = `${scriptSrc}?id=` + i + dl;
           f.parentNode.insertBefore(j, f);
         })(window, document, 'script', dataLayerName, containerId);
         /* eslint-enable */

--- a/packages/analytics-plugin-google-tag-manager/src/browser.js
+++ b/packages/analytics-plugin-google-tag-manager/src/browser.js
@@ -31,8 +31,8 @@ function googleTagManager(pluginConfig = {}) {
       ...config,
       ...pluginConfig
     },
-    initialize: ({ config, customScriptSrc }) => {
-      const { containerId, dataLayerName } = config
+    initialize: ({ config }) => {
+      const { containerId, dataLayerName, customScriptSrc } = config
       if (!containerId) {
         throw new Error('No google tag manager containerId defined')
       }

--- a/site/main/source/plugins/google-tag-manager.md
+++ b/site/main/source/plugins/google-tag-manager.md
@@ -79,8 +79,8 @@ The `@analytics/google-tag-manager` package works in [the browser](#browser-usag
 
 The Google Tag Manager client side browser plugin works with these analytic api methods:
 
-- **[analytics.page](https://getanalytics.io/api/#analyticspage)** - Sends page views into Google Tag Manager 
-- **[analytics.track](https://getanalytics.io/api/#analyticstrack)** - Track custom events and send to Google Tag Manager 
+- **[analytics.page](https://getanalytics.io/api/#analyticspage)** - Sends page views into Google Tag Manager
+- **[analytics.track](https://getanalytics.io/api/#analyticstrack)** - Track custom events and send to Google Tag Manager
 
 ### Browser API
 
@@ -105,6 +105,7 @@ const analytics = Analytics({
 |:---------------------------|:-----------|
 | `containerId` <br/>**required** - string| The Container ID uniquely identifies the GTM Container. |
 | `dataLayerName` <br/>_optional_ - string| The optional name for dataLayer-object. Defaults to dataLayer. |
+| `customScriptSrc` <br/>_optional_ - string| Load Google Tag Manager script from a custom source |
 
 ## Additional examples
 


### PR DESCRIPTION
Add the possibility to inject a customScriptSrc for `google-tag-manager` plugin.


