### PR TITLE
feat: add integrations config option to segment

### DIFF
--- a/packages/analytics-plugin-segment/src/browser.js
+++ b/packages/analytics-plugin-segment/src/browser.js
@@ -7,6 +7,8 @@ const config = {
   disableAnonymousTraffic: false,
   /* Sync segment Anonymous id with `analytics` Anon id */
   syncAnonymousId: false,
+  /* Enable/disable segment destinations https://bit.ly/38nRBj3 */
+  integrations: {}
   /* Override the Segment snippet url, for loading via custom CDN proxy */
 }
 
@@ -115,26 +117,39 @@ function segmentPlugin(pluginConfig = {}) {
       /* eslint-enable */
     },
     /* Trigger Segment page view http://bit.ly/2LSPFr1 */
-    page: ({ payload }) => {
+    page: ({ payload, config }) => {
       if (typeof analytics === 'undefined') return
 
-      analytics.page(payload.properties)
+      analytics.page(payload.properties, {
+        integrations: config.integrations,
+        ...payload.options,
+      })
     },
     /* Track Segment event http://bit.ly/2WLnYkK */
-    track: ({ payload }) => {
+    track: ({ payload, config }) => {
       if (typeof analytics === 'undefined') return
-      // TODO map options from https://getanalytics.io/api/#analyticstrack to segment https://bit.ly/3lAfjhH
-      analytics.track(payload.event, payload.properties, payload.options)
+
+      analytics.track(payload.event, payload.properties, {
+        integrations: config.integrations,
+        ...payload.options,
+      })
     },
     /* Identify Segment user http://bit.ly/2VL45xD */
-    identify: ({ payload }) => {
+    identify: ({ payload, config }) => {
       if (typeof analytics === 'undefined') return
-      const { userId, traits } = payload
+
+      const { userId, traits, options } = payload
 
       if (typeof userId === 'string') {
-        analytics.identify(userId, traits)
+        analytics.identify(userId, traits, {
+          integrations: config.integrations,
+          ...options,
+        })
       } else {
-        analytics.identify(traits)
+        analytics.identify(traits, {
+          integrations: config.integrations,
+          ...options,
+        })
       }
     },
     /* Remove segment cookies on analytics.reset */


### PR DESCRIPTION
## Included changes

* Add `integrations` option to config object that will be passed to each method
* Add `option` parameter to `track`, `page`, and `identify` Segment methods

## Motivation

This package is a great alternative to Segment, and if you have integrations that you're looking to remove from Segment.io and into this package as a plugin you may want to add the plugin and tell Segment to no longer send events to that destination - ideally at the same time to avoid duplicate events.

### Example:
Several destinations are set up in Segment, one of them being Google Analytics. We want to move Google Analytics out of Segment and into `analytics` using `@analytics/google-analytics`.

```js
const analytics = Analytics({
  app: 'my-app',
  plugins: [
    segmentAnalytics({
      write_key: process.env.REACT_APP_SEGMENT_KEY,
    }),
    googleAnalytics({
      trackingId: process.env.REACT_APP_GA_TRACKING_ID,
    }),
  ],
})
```

But, to avoid duplicate events, we'll want to tell Segment to stop sending events to Google Analytics. We can do this by turning off the integration with this options object
```js
{
  integrations: {
    'Google Analytics': false,
  }
}
```

```js
const analytics = Analytics({
  app: 'my-app',
  plugins: [
    segmentAnalytics({
      write_key: process.env.REACT_APP_SEGMENT_KEY,
      integrations: {
        'Google Analytics': false, // Turn off GA as it'll call it's own events
      }
    }),
    googleAnalytics({
      trackingId: process.env.REACT_APP_GA_TRACKING_ID,
    }),
  ],
})
```

This way when this code gets deployed, then events will be sent directly through GA and cut-off in Segment simultaneously.