### PR TITLE
Add FIPS option for Pinpoint plugin.

### DIFF
--- a/packages/analytics-plugin-aws-pinpoint/CHANGELOG.md
+++ b/packages/analytics-plugin-aws-pinpoint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+### Added
+* Add a `fips` config option so that requests use the AWS FIPS endpoint
+
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 

--- a/packages/analytics-plugin-aws-pinpoint/README.md
+++ b/packages/analytics-plugin-aws-pinpoint/README.md
@@ -119,6 +119,7 @@ const analytics = Analytics({
 | `appPackageName` <br/>_optional_ - string| The name of the app package, such as com.example.my_app. |
 | `appVersionCode` <br/>_optional_ - string| The version number of the app, such as 3.2.0 |
 | `disableAnonymousTraffic` <br/>_optional_ - boolean| Disable anonymous events from firing |
+| `fips` <br />_optional_ - boolean| Use the AWS FIPS service endpoint for Pinpoint |
 
 
 ## Additional examples

--- a/packages/analytics-plugin-aws-pinpoint/src/pinpoint/index.js
+++ b/packages/analytics-plugin-aws-pinpoint/src/pinpoint/index.js
@@ -417,8 +417,9 @@ async function callAWS(eventsRequest, config) {
 	
 	const lambda_region = lambdaRegion || pinpointRegion
 	const pinpoint_region = pinpointRegion || lambdaRegion
+	const fips = config.fips === true ? '-fips' : ''
 	const LAMBDA_FN = `https://lambda.${lambda_region}.amazonaws.com/2015-03-31/functions/${lambdaArn}/invocations`
-	const PINPOINT_URL = `https://pinpoint.${pinpoint_region}.amazonaws.com/v1/apps/${pinpointAppId}/events`
+	const PINPOINT_URL = `https://pinpoint${fips}.${pinpoint_region}.amazonaws.com/v1/apps/${pinpointAppId}/events`
 	const endpointUrl = (lambdaArn) ? LAMBDA_FN : PINPOINT_URL
 	
 	const data = await aws.fetch(endpointUrl, {


### PR DESCRIPTION
Some applications require Pinpoint requests use the AWS FIPS (Federal Information Processing Standard) compliant endpoint.  See [here](https://aws.amazon.com/compliance/fips/).  This PR add a `fips` config option the forces the use of FIPS endpoint.