### PR TITLE
analytics-utils: Generate TypeScript definitions using TSC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist
 misc
 queues
 TODO.md
+types/

--- a/packages/analytics-utils/package.json
+++ b/packages/analytics-utils/package.json
@@ -62,5 +62,8 @@
   "dependencies": {
     "@analytics/storage-utils": "^0.2.4",
     "dlv": "^1.1.3"
+  },
+  "peerDependencies": {
+    "@types/dlv": "^1.0.0"
   }
 }

--- a/packages/analytics-utils/package.json
+++ b/packages/analytics-utils/package.json
@@ -13,17 +13,18 @@
   },
   "scripts": {
     "watch": "rollup -w -c scripts/rollup.config.browser.es.js",
-    "clean": "rimraf lib dist && mkdirp lib dist",
+    "clean": "rimraf lib dist types && mkdirp lib dist types",
     "rollup-cjs": "rollup -c scripts/rollup.config.cjs.js && rollup -c scripts/rollup.config.browser.cjs.js",
     "rollup-es": "rollup -c scripts/rollup.config.es.js && rollup -c scripts/rollup.config.browser.es.js",
     "rollup-iife": "rollup -c scripts/rollup.config.iife.js",
     "rollup": "npm-run-all --parallel rollup-cjs rollup-es rollup-iife",
     "minify-dist": "uglifyjs -mc < dist/analytics-utils.js > dist/analytics-utils.min.js",
-    "build": "npm-run-all clean rollup minify-dist",
+    "build": "npm-run-all clean rollup types minify-dist",
     "publish": "git push origin && git push origin --tags",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
-    "release:major": "npm version major && npm publish"
+    "release:major": "npm version major && npm publish",
+    "types": "tsc"
   },
   "keywords": [
     "analytics",
@@ -35,6 +36,7 @@
     "lib",
     "README.md"
   ],
+  "types": "./types/index.d.ts",
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "^0.8.5",
     "@babel/core": "^7.2.2",
@@ -54,6 +56,7 @@
     "rollup-plugin-strip-banner": "^0.2.0",
     "rollup-plugin-terser": "^4.0.3",
     "rollup-plugin-uglify": "^6.0.2",
+    "typescript": "^4.2.3",
     "uglify-js": "^3.4.9"
   },
   "dependencies": {

--- a/packages/analytics-utils/src/detectAdBlock.js
+++ b/packages/analytics-utils/src/detectAdBlock.js
@@ -1,5 +1,10 @@
 import inBrowser from './inBrowser'
 
+/** 
+ * Determine if Adblock is installed
+ *
+ * @returns boolean
+ */
 export default function hasAdblock() {
   if (!inBrowser) return false
   // Create fake ad

--- a/packages/analytics-utils/src/getBrowserLocale.js
+++ b/packages/analytics-utils/src/getBrowserLocale.js
@@ -1,5 +1,8 @@
 import inBrowser from './inBrowser'
 
+/**
+ * @returns {string | undefined}
+ */
 export default function getBrowserLocale() {
   if (!inBrowser) return
   const { language, languages, userLanguage } = navigator

--- a/packages/analytics-utils/src/getTimeZone.js
+++ b/packages/analytics-utils/src/getTimeZone.js
@@ -1,4 +1,7 @@
 
+/**
+ * @returns {string | undefined}
+ */
 export default function getTimeZone() {
   try {
     return Intl.DateTimeFormat().resolvedOptions().timeZone

--- a/packages/analytics-utils/src/inBrowser.js
+++ b/packages/analytics-utils/src/inBrowser.js
@@ -1,5 +1,5 @@
 /**
  * In browser context
- * @return {Boolean} true if in browser
+ * @type boolean true if in browser
  */
 export default typeof document !== 'undefined'

--- a/packages/analytics-utils/src/isExternalReferrer.js
+++ b/packages/analytics-utils/src/isExternalReferrer.js
@@ -1,5 +1,9 @@
 import inBrowser from './inBrowser'
 
+/**
+ * @param {string | null | undefined} ref
+ * @returns {boolean | undefined}
+ */
 export default function isExternalReferrer(ref) {
   if (!inBrowser) return false
   const referrer = ref || document.referrer

--- a/packages/analytics-utils/src/onRouteChange.js
+++ b/packages/analytics-utils/src/onRouteChange.js
@@ -1,6 +1,16 @@
 import inBrowser from './inBrowser'
 import noOp from './noOp'
 
+/**
+ * @callback RouteChangeHandler
+ * @param {string} pathName
+ * @returns {void}
+ */
+
+/**
+ * @param {RouteChangeHandler} callback
+ * @returns {void}
+ */
 export default function onRouteChange(callback = noOp) {
   if (!inBrowser) return
   const { addEventListener, history, location } = window

--- a/packages/analytics-utils/src/paramsRemove.js
+++ b/packages/analytics-utils/src/paramsRemove.js
@@ -4,8 +4,8 @@ import paramsClean from './paramsClean'
 /**
  * Removes params from url in browser
  * @param  {string}   param       - param key to remove from current URL
- * @param  {function} [callback]  - callback function to run. Only runs in browser
- * @return {promise}
+ * @param  {() => void} [callback]  - callback function to run. Only runs in browser
+ * @return {PromiseLike<void>}
  */
 export default function paramsRemove(param, callback) {
   if (!inBrowser) return Promise.resolve()

--- a/packages/analytics-utils/src/parseReferrer.js
+++ b/packages/analytics-utils/src/parseReferrer.js
@@ -4,11 +4,19 @@ import isExternalReferrer from './isExternalReferrer'
 import { trimTld, getDomainBase } from './url'
 
 const googleKey = 'google'
+
+/**
+ * @typedef {{
+ *  campaign: string,
+ *  referrer?: string,
+ * } & DomainObject & Object.<string, any>} ReferrerObject
+ */
+
 /**
  * Checks a given url and parses referrer data
  * @param  {String} [referrer] - (optional) referring URL
  * @param  {String} [currentUrl] - (optional) the current url
- * @return {Object}     [description]
+ * @return {ReferrerObject}     [description]
  */
 export default function parseReferrer(referrer, currentUrl) {
   if (!inBrowser) return false
@@ -57,9 +65,17 @@ export default function parseReferrer(referrer, currentUrl) {
 }
 
 /**
+ * @typedef {{
+ *  source: string,
+ *  medium: string,
+ *  term?: string
+ * }} DomainObject
+ */
+
+/**
  * Client side domain parser for determining marketing data.
  * @param  {String} referrer - ref url
- * @return {Object}
+ * @return {DomainObject | boolean}
  */
 function parseDomain(referrer) {
   if (!referrer || !inBrowser) return false

--- a/packages/analytics-utils/src/throttle.js
+++ b/packages/analytics-utils/src/throttle.js
@@ -1,3 +1,9 @@
+/**
+ * @template {Function} F;
+ * @param {F} func;
+ * @param {number} wait;
+ * @return {F};
+ */
 export default function throttle(func, wait) {
   var context, args, result
   var timeout = null

--- a/packages/analytics-utils/src/typeCheck.js
+++ b/packages/analytics-utils/src/typeCheck.js
@@ -1,23 +1,49 @@
+/** 
+ * @param x
+ * @return {x is Function}
+ */
 export function isFunction(x) {
   return typeof x === 'function'
 }
 
+/** 
+ * @param x
+ * @return {x is string}
+ */
 export function isString(x) {
   return typeof x === 'string'
 }
 
+
+/** 
+ * @param x
+ * @return {x is undefined}
+ */
 export function isUndefined(x) {
   return typeof x === 'undefined'
 }
 
+/** 
+ * @param x
+ * @return {x is boolean}
+ */
 export function isBoolean(x) {
   return typeof x === 'boolean'
 }
 
+/** 
+ * @template T
+ * @param x
+ * @return {x is Array<T>}
+ */
 export function isArray(x) {
   return Array.isArray(x)
 }
 
+/** 
+ * @param obj
+ * @return {obj is Object}
+ */
 export function isObject(obj) {
   if (typeof obj !== 'object' || obj === null) return false
 

--- a/packages/analytics-utils/src/uuid.js
+++ b/packages/analytics-utils/src/uuid.js
@@ -1,4 +1,7 @@
 /* ref: http://bit.ly/2daP79j */
+/**
+ * @return {string}
+ */
 export default function uuid() {
   var u = '',
   m = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx',

--- a/packages/analytics-utils/tsconfig.json
+++ b/packages/analytics-utils/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "include": [
+      "./src/**/*"
+  ],
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "allowJs": true,
+    "declaration": true,
+    "outDir": "./types",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "emitDeclarationOnly": true
+  }
+}


### PR DESCRIPTION
As discussed in #151, this PR implements TypeScript definitions output using `tsc` instead of JSDoc and includes them in the build of `analytics-utils`. 

I also improved some of the JSDoc definitions, and added some that were missing. 