### PR TITLE
Add repository to analytics-utils/package.json

### DIFF
--- a/packages/analytics-utils/package.json
+++ b/packages/analytics-utils/package.json
@@ -26,6 +26,10 @@
     "release:major": "npm version major && npm publish",
     "types": "tsc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DavidWells/analytics"
+  },
   "keywords": [
     "analytics",
     "analytics-project",


### PR DESCRIPTION
Reason: We have been doing audit of all our dependencies in our company due to an upcoming project code review and npm dependency analytics-utils did not report any repository using `npm view analytics-utils --json`

Solution: I have added the repository to the corresponding package.json file.