### PR TITLE
Amplitude plugin for browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,7 @@ Below is a list of the current available events
 The `analytics` has a robust plugin system. Here is a list of currently available plugins:
 
 <!-- AUTO-GENERATED-CONTENT:START (PLUGINS) -->
+- [@analytics/amplitude-browser](https://github.com/DavidWells/analytics/tree/master/packages/analytics-plugin-amplitude-browser) Amplitude browser plugin for 'analytics' module [npm link](https://www.npmjs.com/package/@analytics/amplitude-browser).
 - [@analytics/aws-pinpoint](https://github.com/DavidWells/analytics/tree/master/packages/analytics-plugin-aws-pinpoint) AWS Pinpoint integration for 'analytics' module [npm link](https://www.npmjs.com/package/@analytics/aws-pinpoint).
 - [@analytics/cookie-utils](https://github.com/DavidWells/analytics/tree/master/packages/analytics-util-cookie) Cookie helper functions [npm link](https://www.npmjs.com/package/@analytics/cookie-utils).
 - [@analytics/core](https://github.com/DavidWells/analytics/tree/master/packages/analytics-core) Lightweight analytics library for tracking events, page views, & identifying users. Works with any third party analytics provider via an extendable plugin system. [npm link](https://www.npmjs.com/package/@analytics/core).

--- a/packages/analytics-core/README.md
+++ b/packages/analytics-core/README.md
@@ -681,6 +681,7 @@ Below is a list of the current available events
 The `analytics` has a robust plugin system. Here is a list of currently available plugins:
 
 <!-- AUTO-GENERATED-CONTENT:START (PLUGINS) -->
+- [@analytics/amplitude-browser](https://github.com/DavidWells/analytics/tree/master/packages/analytics-plugin-amplitude-browser) Amplitude browser plugin for 'analytics' module [npm link](https://www.npmjs.com/package/@analytics/amplitude-browser).
 - [@analytics/aws-pinpoint](https://github.com/DavidWells/analytics/tree/master/packages/analytics-plugin-aws-pinpoint) AWS Pinpoint integration for 'analytics' module [npm link](https://www.npmjs.com/package/@analytics/aws-pinpoint).
 - [@analytics/cookie-utils](https://github.com/DavidWells/analytics/tree/master/packages/analytics-util-cookie) Cookie helper functions [npm link](https://www.npmjs.com/package/@analytics/cookie-utils).
 - [@analytics/core](https://github.com/DavidWells/analytics/tree/master/packages/analytics-core) Lightweight analytics library for tracking events, page views, & identifying users. Works with any third party analytics provider via an extendable plugin system. [npm link](https://www.npmjs.com/package/@analytics/core).

--- a/packages/analytics-plugin-amplitude-browser/.babelrc
+++ b/packages/analytics-plugin-amplitude-browser/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    [
+      "@babel/env", {
+      "modules": false
+      }
+    ]
+  ]
+}

--- a/packages/analytics-plugin-amplitude-browser/.gitignore
+++ b/packages/analytics-plugin-amplitude-browser/.gitignore
@@ -1,0 +1,13 @@
+dist
+node_modules
+lib
+temp-types
+*.log
+yarn.lock
+
+# IDE stuff
+**/.idea
+
+# OS stuff
+.DS_Store
+.tmp

--- a/packages/analytics-plugin-amplitude-browser/CHANGELOG.md
+++ b/packages/analytics-plugin-amplitude-browser/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/analytics-plugin-amplitude-browser/README.md
+++ b/packages/analytics-plugin-amplitude-browser/README.md
@@ -1,0 +1,245 @@
+<!--
+title: Adding Amplitude to your app using open source analytics
+description: Connect Amplitude to the analytics library
+pageTitle: Amplitude
+-->
+
+# Amplitude
+
+This library exports the `amplitude` plugin for the [`analytics`](https://www.npmjs.com/package/analytics) package.
+
+This analytics plugin will load Amplitude integration into your application.
+
+For more information [see the docs](https://getanalytics.io/plugins/amplitude/).
+
+<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click to expand) -->
+<details>
+<summary>Click to expand</summary>
+
+- [Installation](#installation)
+- [How to use](#how-to-use)
+- [Platforms Supported](#platforms-supported)
+- [Browser usage](#browser-usage)
+  * [Browser API](#browser-api)
+  * [Configuration options for browser](#configuration-options-for-browser)
+- [Additional examples](#additional-examples)
+
+</details>
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+## Installation
+
+```bash
+npm install analytics
+npm install @analytics/amplitude
+```
+
+<!-- AUTO-GENERATED-CONTENT:START (PLUGIN_DOCS) -->
+
+## How to use
+
+The `@analytics/amplitude-browser` package works in [the browser](#browser-usage). To use, install the package, include in your project and initialize the plugin with [analytics](https://www.npmjs.com/package/analytics).
+
+Below is an example of how to use the browser plugin.
+
+```js
+import Analytics from 'analytics'
+import exports from '@analytics/amplitude-browser'
+
+const analytics = Analytics({
+  app: 'awesome-app',
+  plugins: [
+    amplitude({
+      apiKey: 'token',
+      options: {
+        trackingOptions: {
+          ip_address: false
+        }
+      }
+    })
+  ]
+})
+
+/* Track a page view */
+analytics.page()
+
+/* Track a custom event */
+analytics.track('cartCheckout', {
+  item: 'pink socks',
+  price: 20
+})
+
+/* Identify a visitor */
+analytics.identify('user-id-xyz', {
+  firstName: 'bill',
+  lastName: 'murray'
+})
+
+```
+
+After initializing `analytics` with the `exports` plugin, data will be sent into Amplitude whenever [analytics.page](https://getanalytics.io/api/#analyticspage), [analytics.track](https://getanalytics.io/api/#analyticstrack), or [analytics.identify](https://getanalytics.io/api/#analyticsidentify) are called.
+
+See [additional implementation examples](#additional-examples) for more details on using in your project.
+
+## Platforms Supported
+
+The `@analytics/amplitude-browser` package works in [the browser](#browser-usage)
+
+## Browser usage
+
+The Amplitude client side browser plugin works with these analytic api methods:
+
+- **[analytics.page](https://getanalytics.io/api/#analyticspage)** - Sends page views into Amplitude
+- **[analytics.track](https://getanalytics.io/api/#analyticstrack)** - Track custom events and send to Amplitude
+- **[analytics.identify](https://getanalytics.io/api/#analyticsidentify)** - Identify visitors and send details to Amplitude
+
+### Browser API
+
+```js
+import Analytics from 'analytics'
+import exports from '@analytics/amplitude-browser'
+
+const analytics = Analytics({
+  app: 'awesome-app',
+  plugins: [
+    amplitude({
+      apiKey: 'token',
+      options: {
+        trackingOptions: {
+          ip_address: false
+        }
+      }
+    })
+  ]
+})
+
+```
+
+### Configuration options for browser
+
+| Option | description |
+|:---------------------------|:-----------|
+| `apiKey` <br/>**required** - string| Amplitude project API key |
+| `projectName` <br/>**required** - string| project name (if it's necessary to report to multiple projects) |
+| `options` <br/>**required** - object| Amplitude SDK options |
+
+
+## Additional examples
+
+Below are additional implementation examples.
+
+<details>
+  <summary>Using in HTML</summary>
+
+  Below is an example of importing via the unpkg CDN. Please note this will pull in the latest version of the package.
+
+  ```html
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <title>Using @analytics/amplitude-browser in HTML</title>
+      <script src="https://unpkg.com/analytics/dist/analytics.min.js"></script>
+      <script src="https://unpkg.com/@analytics/amplitude-browser/dist/@analytics/amplitude-browser.min.js"></script>
+      <script type="text/javascript">
+        /* Initialize analytics */
+        var Analytics = _analytics.init({
+          app: 'my-app-name',
+          plugins: [
+            amplitude({
+              apiKey: 'token',
+              options: {
+                trackingOptions: {
+                  ip_address: false
+                }
+              }
+            })
+          ]
+        })
+
+        /* Track a page view */
+        analytics.page()
+
+        /* Track a custom event */
+        analytics.track('cartCheckout', {
+          item: 'pink socks',
+          price: 20
+        })
+
+        /* Identify a visitor */
+        analytics.identify('user-id-xyz', {
+          firstName: 'bill',
+          lastName: 'murray'
+        })
+      </script>
+    </head>
+    <body>
+      ....
+    </body>
+  </html>
+
+  ```
+
+</details>
+
+<details>
+  <summary>Using in HTML via ES Modules</summary>
+
+  Using `@analytics/amplitude-browser` in ESM modules.
+
+  ```html
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <title>Using @analytics/amplitude-browser in HTML via ESModules</title>
+      <script>
+        // Polyfill process.
+        // **Note**: Because `import`s are hoisted, we need a separate, prior <script> block.
+        window.process = window.process || { env: { NODE_ENV: 'production' } }
+      </script>
+      <script type="module">
+        import analytics from 'https://unpkg.com/analytics/lib/analytics.browser.es.js?module'
+        import undefined from 'https://unpkg.com/@analytics/amplitude-browser/lib/analytics-plugin-amplitude-browser.browser.es.js?module'
+        /* Initialize analytics */
+        const Analytics = analytics({
+          app: 'analytics-html-demo',
+          debug: true,
+          plugins: [
+            amplitude({
+              apiKey: 'token',
+              options: {
+                trackingOptions: {
+                  ip_address: false
+                }
+              }
+            })
+            // ... add any other third party analytics plugins
+          ]
+        })
+
+        /* Track a page view */
+        analytics.page()
+
+        /* Track a custom event */
+        analytics.track('cartCheckout', {
+          item: 'pink socks',
+          price: 20
+        })
+
+        /* Identify a visitor */
+        analytics.identify('user-id-xyz', {
+          firstName: 'bill',
+          lastName: 'murray'
+        })
+      </script>
+    </head>
+    <body>
+      ....
+    </body>
+  </html>
+
+  ```
+
+</details>
+
+
+<!-- AUTO-GENERATED-CONTENT:END (PLUGIN_DOCS) -->

--- a/packages/analytics-plugin-amplitude-browser/package.json
+++ b/packages/analytics-plugin-amplitude-browser/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@analytics/amplitude-browser",
+  "version": "0.1.0",
+  "description": "Amplitude browser plugin for 'analytics' module",
+  "projectMeta": {
+    "provider": {
+      "name": "Amplitude",
+      "url": "https://amplitude.com/"
+    },
+    "windowGlobal": "analyticsAmplitude",
+    "platforms": {
+      "browser": "./src/index.js"
+    }
+  },
+  "keywords": [
+    "analytics",
+    "analytics-project",
+    "analytics-plugin",
+    "amplitude"
+  ],
+  "author": "Roman Mazur",
+  "license": "MIT",
+  "scripts": {
+    "docs": "node ../analytics-cli/bin/run docs",
+    "types": "../../node_modules/.bin/jsdoc -t ../../node_modules/tsd-jsdoc/dist -r ./src/ -d temp-types",
+    "build": "node ../../scripts/build/index.js",
+    "watch": "node ../../scripts/build/_watch.js",
+    "release:patch": "npm version patch && npm publish",
+    "release:minor": "npm version minor && npm publish",
+    "release:major": "npm version major && npm publish",
+    "es": "../../node_modules/.bin/babel-node ./testBabel.js"
+  },
+  "main": "lib/analytics-plugin-amplitude-browser.cjs.js",
+  "jsnext:main": "lib/analytics-plugin-amplitude-browser.es.js",
+  "module": "lib/analytics-plugin-amplitude-browser.es.js",
+  "browser": {
+    "./lib/analytics-plugin-amplitude-browser.cjs.js": "./lib/analytics-plugin-amplitude-browser.browser.cjs.js",
+    "./lib/analytics-plugin-amplitude-browser.es.js": "./lib/analytics-plugin-amplitude-browser.browser.es.js"
+  },
+  "files": [
+    "dist",
+    "lib",
+    "README.md"
+  ],
+  "homepage": "https://github.com/DavidWells/analytics#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DavidWells/analytics.git"
+  },
+  "devDependencies": {
+    "@babel/core": "7.5.5",
+    "@babel/preset-env": "7.5.5"
+  },
+  "dependencies": {}
+}

--- a/packages/analytics-plugin-amplitude-browser/src/index.js
+++ b/packages/analytics-plugin-amplitude-browser/src/index.js
@@ -25,11 +25,6 @@ export default function amplitudeBrowserPlugin (pluginConfig = {}) {
   // Flag is set to true after amplitude client instance is initialized.
   let amplitudeInitCompleted = false;
 
-  const scriptLoaded = (scriptSrc) => {
-    const scripts = document.querySelectorAll('script[src]')
-    return !!Object.keys(scripts).filter((key) => (scripts[key].src || '') === scriptSrc).length
-  }
-
   const initComplete = (d) => {
     client = d;
     amplitudeInitCompleted = true;
@@ -95,7 +90,6 @@ export default function amplitudeBrowserPlugin (pluginConfig = {}) {
     },
 
     identify: ({ payload: { userId, traits }, instance }) => {
-      client.setDeviceId(instance.user("anonymousId"))
       client.setUserId(userId)
       client.setUserProperties(traits)
     },

--- a/packages/analytics-plugin-amplitude-browser/src/index.js
+++ b/packages/analytics-plugin-amplitude-browser/src/index.js
@@ -1,0 +1,105 @@
+/**
+ * Amplitude plugin
+ * @link https://getanalytics.io/plugins/amplitude/
+ * @link https://amplitude.com/
+ * @link https://developers.amplitude.com
+ * @param {object} pluginConfig - Plugin settings
+ * @param {string} pluginConfig.apiKey - Amplitude project API key
+ * @param {string} pluginConfig.projectName - project name (if it's necessary to report to multiple projects)
+ * @param {object} pluginConfig.options - Amplitude SDK options
+ * @return {*}
+ * @example
+ *
+ * amplitude({
+ *   apiKey: 'token',
+ *   options: { 
+ *     trackingOptions: {
+ *       ip_address: false 
+ *     } 
+ *   }
+ * })
+ */
+export default function amplitudeBrowserPlugin (pluginConfig = {}) {
+  // Amplitude client instance.
+  let client = null;
+  // Flag is set to true after amplitude client instance is initialized.
+  let amplitudeInitCompleted = false;
+
+  const scriptLoaded = (scriptSrc) => {
+    const scripts = document.querySelectorAll('script[src]')
+    return !!Object.keys(scripts).filter((key) => (scripts[key].src || '') === scriptSrc).length
+  }
+
+  const initComplete = (d) => {
+    client = d;
+    amplitudeInitCompleted = true;
+  };
+
+  return {
+    name: "amplitude",
+    config: pluginConfig,
+    // For Amplitude options, see https://amplitude.github.io/Amplitude-JavaScript/Options
+    initialize: ({ config }) => {
+      const { apiKey, projectName, customScriptSrc, options = {} } = config;
+      if (!apiKey) {
+        throw new Error("Amplitude project API key is not defined");
+      }
+      if (options && typeof options !== "object") {
+        throw new Error("Amplitude SDK options must be an object");
+      }
+
+      // Already loaded
+      if (typeof window.amplitude !== 'undefined') {
+        return;
+      }
+      
+      const  scriptSrc = customScriptSrc ? customScriptSrc : 'https://cdn.amplitude.com/libs/amplitude-8.1.0-min.gz.js';
+
+      (function(e,t){var n=e.amplitude||{_q:[],_iq:{}};var r=t.createElement("script")
+      ;r.type="text/javascript"
+      ;r.integrity="sha384-u0hlTAJ1tNefeBKwiBNwB4CkHZ1ck4ajx/pKmwWtc+IufKJiCQZ+WjJIi+7C6Ntm"
+      ;r.crossOrigin="anonymous";r.async=true
+      ;r.src=scriptSrc
+      ;r.onload=function(){if(!e.amplitude.runQueuedFunctions){
+      console.log("[Amplitude] Error: could not load SDK")}}
+      ;var i=t.getElementsByTagName("script")[0];i.parentNode.insertBefore(r,i)
+      ;function s(e,t){e.prototype[t]=function(){
+      this._q.push([t].concat(Array.prototype.slice.call(arguments,0)));return this}}
+      var o=function(){this._q=[];return this}
+      ;var a=["add","append","clearAll","prepend","set","setOnce","unset","preInsert","postInsert","remove"]
+      ;for(var c=0;c<a.length;c++){s(o,a[c])}n.Identify=o;var u=function(){this._q=[]
+      ;return this}
+      ;var l=["setProductId","setQuantity","setPrice","setRevenueType","setEventProperties"]
+      ;for(var p=0;p<l.length;p++){s(u,l[p])}n.Revenue=u
+      ;var d=["init","logEvent","logRevenue","setUserId","setUserProperties","setOptOut","setVersionName","setDomain","setDeviceId","enableTracking","setGlobalUserProperties","identify","clearUserProperties","setGroup","logRevenueV2","regenerateDeviceId","groupIdentify","onInit","logEventWithTimestamp","logEventWithGroups","setSessionId","resetSessionId"]
+      ;function v(e){function t(t){e[t]=function(){
+      e._q.push([t].concat(Array.prototype.slice.call(arguments,0)))}}
+      for(var n=0;n<d.length;n++){t(d[n])}}v(n);n.getInstance=function(e){
+      e=(!e||e.length===0?"$default_instance":e).toLowerCase()
+      ;if(!Object.prototype.hasOwnProperty.call(n._iq,e)){n._iq[e]={_q:[]};v(n._iq[e])
+      }return n._iq[e]};e.amplitude=n})(window,document);
+    
+      window.amplitude.init(config.apiKey, null, options, initComplete)
+    },
+
+    page: ({ payload: { properties, options } }) => {
+      let eventType = "Page View"
+      if (options && options.eventType) {
+        eventType = options.eventType
+      }
+       client.logEvent(eventType, properties)
+    },
+
+    track: ({ payload: { event, properties } }) => {
+       client.logEvent(event, properties)
+    },
+
+    identify: ({ payload: { userId, traits }, instance }) => {
+      client.setDeviceId(instance.user("anonymousId"))
+      client.setUserId(userId)
+      client.setUserProperties(traits)
+    },
+
+    loaded: () => amplitudeInitCompleted,
+  };
+}

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -683,6 +683,7 @@ Below is a list of the current available events
 The `analytics` has a robust plugin system. Here is a list of currently available plugins:
 
 <!-- AUTO-GENERATED-CONTENT:START (PLUGINS) -->
+- [@analytics/amplitude-browser](https://github.com/DavidWells/analytics/tree/master/packages/analytics-plugin-amplitude-browser) Amplitude browser plugin for 'analytics' module [npm link](https://www.npmjs.com/package/@analytics/amplitude-browser).
 - [@analytics/aws-pinpoint](https://github.com/DavidWells/analytics/tree/master/packages/analytics-plugin-aws-pinpoint) AWS Pinpoint integration for 'analytics' module [npm link](https://www.npmjs.com/package/@analytics/aws-pinpoint).
 - [@analytics/cookie-utils](https://github.com/DavidWells/analytics/tree/master/packages/analytics-util-cookie) Cookie helper functions [npm link](https://www.npmjs.com/package/@analytics/cookie-utils).
 - [@analytics/core](https://github.com/DavidWells/analytics/tree/master/packages/analytics-core) Lightweight analytics library for tracking events, page views, & identifying users. Works with any third party analytics provider via an extendable plugin system. [npm link](https://www.npmjs.com/package/@analytics/core).


### PR DESCRIPTION
This PR is based on the great work by @roman-mazur in PR #19. One of the blockers has been how the Amplitude library is loaded. This PR removes the dependency to `amplitude-js` and loads the SDK as described in issue #142.