### PR TITLE
Amplitude plugin: Terminate ternary operator with semicolon to avoid runtime error

### DIFF
--- a/packages/analytics-plugin-amplitude/src/browser.js
+++ b/packages/analytics-plugin-amplitude/src/browser.js
@@ -48,7 +48,7 @@ function amplitudePlugin(pluginConfig = {}) {
         return
       }
       
-      const scriptSrc = customScriptSrc ? customScriptSrc : 'https://cdn.amplitude.com/libs/amplitude-8.1.0-min.gz.js'
+      const scriptSrc = customScriptSrc ? customScriptSrc : 'https://cdn.amplitude.com/libs/amplitude-8.1.0-min.gz.js';
 
       // Initialize amplitude js
       (function(e, t) {


### PR DESCRIPTION
A missing semicolon makes the Amplitude plugin barf at runtime, see #169 .