### PR TITLE
Improve mixpanel page events

### DIFF
--- a/packages/analytics-plugin-mixpanel/README.md
+++ b/packages/analytics-plugin-mixpanel/README.md
@@ -111,6 +111,7 @@ const analytics = Analytics({
 | Option | description |
 |:---------------------------|:-----------|
 | `token` <br/>**required** - string| The mixpanel token associated to a mixpanel project |
+| `pageEvent` <br/>_optional_ - string| Event name to use for page() events (default to page path) |
 | `customScriptSrc` <br/>_optional_ - string| Load mixpanel script from custom source |
 
 

--- a/packages/analytics-plugin-mixpanel/src/browser.js
+++ b/packages/analytics-plugin-mixpanel/src/browser.js
@@ -3,6 +3,7 @@
  * @link https://getanalytics.io/plugins/mixpanel/
  * @param {object} pluginConfig - Plugin settings
  * @param {string} pluginConfig.token - The mixpanel token associated to a mixpanel project
+ * @param {string} [pluginConfig.pageEvent] - Event name to use for page() events (default to page path)
  * @param {string} [pluginConfig.customScriptSrc] - Load mixpanel script from custom source
  * @return {object} Analytics plugin
  * @example
@@ -141,7 +142,7 @@ function mixpanelPlugin(pluginConfig = {}) {
      * the path as tracked event and search parameters as properties
      */
     page: ({ payload }) => {
-      mixpanel.track(payload.properties.path, payload.properties);
+      mixpanel.track(pluginConfig.pageEvent || payload.properties.path, payload.properties);
     },
     /* https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpaneltrack */
     track: ({ payload }) => {

--- a/packages/analytics-plugin-mixpanel/src/browser.js
+++ b/packages/analytics-plugin-mixpanel/src/browser.js
@@ -3,6 +3,7 @@
  * @link https://getanalytics.io/plugins/mixpanel/
  * @param {object} pluginConfig - Plugin settings
  * @param {string} pluginConfig.token - The mixpanel token associated to a mixpanel project
+ * @param {object} [pluginConfig.options] - The mixpanel init options https://github.com/mixpanel/mixpanel-js/blob/8b2e1f7b/src/mixpanel-core.js#L87-L110
  * @param {string} [pluginConfig.pageEvent] - Event name to use for page() events (default to page path)
  * @param {string} [pluginConfig.customScriptSrc] - Load mixpanel script from custom source
  * @return {object} Analytics plugin
@@ -18,7 +19,7 @@ function mixpanelPlugin(pluginConfig = {}) {
     config: pluginConfig,
     /* https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelinit */
     initialize: ({ config }) => {
-      const { token, customScriptSrc } = config;
+      const { token, customScriptSrc, options = {} } = config;
       if (!token) {
         throw new Error("No mixpanel token defined");
       }
@@ -119,7 +120,7 @@ function mixpanelPlugin(pluginConfig = {}) {
         }
       })(document, window.mixpanel || []);
 
-      mixpanel.init(config.token, { batch_requests: true });
+      mixpanel.init(config.token, { batch_requests: true, ...options });
     },
     /**
      * Identify a visitor in mixpanel

--- a/packages/analytics-plugin-mixpanel/src/browser.js
+++ b/packages/analytics-plugin-mixpanel/src/browser.js
@@ -141,9 +141,7 @@ function mixpanelPlugin(pluginConfig = {}) {
      * the path as tracked event and search parameters as properties
      */
     page: ({ payload }) => {
-      mixpanel.track(payload.properties.path, {
-        search: payload.properties.search,
-      });
+      mixpanel.track(payload.properties.path, payload.properties);
     },
     /* https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpaneltrack */
     track: ({ payload }) => {


### PR DESCRIPTION
* Send all provided page data, not just `search`
* Allow the event name behaviour to be overridden (same concept is done in #115 )