### PR TITLE
update babel and forcibly set regenerator runtime version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/DavidWells/analytics"
+    "url": "https://github.com/FlightPenguin/analytics"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "^0.8.5",
-    "@babel/core": "^7.5.5",
-    "@babel/plugin-transform-runtime": "^7.5.5",
-    "@babel/preset-env": "7.5.5",
+    "@babel/core": "^7.14.5",
+    "@babel/plugin-transform-runtime": "^7.14.5",
+    "@babel/preset-env": "7.14.5",
     "ava": "^2.3.0",
     "dox": "^0.9.0",
     "doxxx": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/FlightPenguin/analytics"
+    "url": "https://github.com/DavidWells/analytics"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "^0.8.5",

--- a/packages/analytics-cli/package.json
+++ b/packages/analytics-cli/package.json
@@ -15,7 +15,8 @@
     "@oclif/plugin-help": "^2.1.2",
     "dox": "^0.9.0",
     "markdown-magic": "^0.1.25",
-    "prettier": "^1.17.1"
+    "prettier": "^1.17.1",
+    "regenerator-runtime": "^0.13.9"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.17.0",

--- a/packages/analytics-core/package.json
+++ b/packages/analytics-core/package.json
@@ -50,7 +50,8 @@
   "dependencies": {
     "@analytics/global-storage-utils": "^0.1.2",
     "@analytics/type-utils": "^0.3.1",
-    "analytics-utils": "^1.0.2"
+    "analytics-utils": "^1.0.2",
+    "regenerator-runtime": "^0.13.9"
   },
   "ava": {
     "files": [
@@ -67,12 +68,12 @@
     ]
   },
   "devDependencies": {
-    "@babel/core": "7.5.5",
-    "@babel/plugin-proposal-class-properties": "7.5.5",
-    "@babel/plugin-transform-runtime": "7.5.5",
-    "@babel/preset-env": "7.5.5",
-    "@babel/register": "7.5.5",
-    "@babel/runtime": "7.5.5",
+    "@babel/core": "7.14.5",
+    "@babel/plugin-proposal-class-properties": "7.14.5",
+    "@babel/plugin-transform-runtime": "7.14.5",
+    "@babel/preset-env": "7.14.5",
+    "@babel/register": "7.14.5",
+    "@babel/runtime": "7.14.5",
     "ava": "^2.2.0",
     "mkdirp": "^0.5.1",
     "npm-run-all": "^4.1.5",

--- a/packages/analytics-plugin-amplitude/package.json
+++ b/packages/analytics-plugin-amplitude/package.json
@@ -48,7 +48,10 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "7.5.5",
-    "@babel/preset-env": "7.5.5"
+    "@babel/core": "7.14.5",
+    "@babel/preset-env": "7.14.5"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-plugin-aws-pinpoint/package.json
+++ b/packages/analytics-plugin-aws-pinpoint/package.json
@@ -55,11 +55,12 @@
     "analytics-plugin-tab-events": "^0.2.0",
     "analytics-utils": "^1.0.2",
     "aws4fetch": "^1.0.13",
-    "deepmerge": "^4.2.2"
+    "deepmerge": "^4.2.2",
+    "regenerator-runtime": "^0.13.9"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/plugin-transform-runtime": "7.5.5",
-    "@babel/preset-env": "^7.3.1"
+    "@babel/core": "^7.14.5",
+    "@babel/plugin-transform-runtime": "7.14.5",
+    "@babel/preset-env": "^7.14.5"
   }
 }

--- a/packages/analytics-plugin-crazy-egg/package.json
+++ b/packages/analytics-plugin-crazy-egg/package.json
@@ -47,7 +47,10 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/preset-env": "^7.3.1"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-plugin-customerio/package.json
+++ b/packages/analytics-plugin-customerio/package.json
@@ -50,10 +50,11 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/preset-env": "^7.3.1"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
   },
   "dependencies": {
-    "customerio-node": "^0.5.0"
+    "customerio-node": "^0.5.0",
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-plugin-do-not-track/package.json
+++ b/packages/analytics-plugin-do-not-track/package.json
@@ -41,7 +41,10 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/preset-env": "^7.3.1"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-plugin-event-validation/package.json
+++ b/packages/analytics-plugin-event-validation/package.json
@@ -39,7 +39,10 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/preset-env": "^7.3.1"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-plugin-fullstory/package.json
+++ b/packages/analytics-plugin-fullstory/package.json
@@ -63,12 +63,13 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "7.5.5",
-    "@babel/preset-env": "7.5.5",
-    "@babel/register": "^7.5.5",
-    "@babel/runtime": "7.5.5"
+    "@babel/core": "7.14.5",
+    "@babel/preset-env": "7.14.5",
+    "@babel/register": "^7.14.5",
+    "@babel/runtime": "7.14.5"
   },
   "dependencies": {
-    "camelcase": "^5.3.1"
+    "camelcase": "^5.3.1",
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-plugin-google-analytics/package.json
+++ b/packages/analytics-plugin-google-analytics/package.json
@@ -51,10 +51,11 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/preset-env": "^7.3.1"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
   },
   "dependencies": {
+    "regenerator-runtime": "^0.13.9",
     "universal-analytics": "^0.4.20"
   }
 }

--- a/packages/analytics-plugin-google-tag-manager/package.json
+++ b/packages/analytics-plugin-google-tag-manager/package.json
@@ -49,7 +49,10 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/preset-env": "^7.3.1"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-plugin-gosquared/package.json
+++ b/packages/analytics-plugin-gosquared/package.json
@@ -48,7 +48,10 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/preset-env": "^7.3.1"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-plugin-hubspot/package.json
+++ b/packages/analytics-plugin-hubspot/package.json
@@ -48,7 +48,10 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/preset-env": "^7.3.1"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-plugin-lifecycle-example/package.json
+++ b/packages/analytics-plugin-lifecycle-example/package.json
@@ -37,7 +37,10 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/preset-env": "^7.3.1"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-plugin-mixpanel/package.json
+++ b/packages/analytics-plugin-mixpanel/package.json
@@ -48,7 +48,10 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/preset-env": "^7.3.1"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-plugin-original-source/package.json
+++ b/packages/analytics-plugin-original-source/package.json
@@ -46,7 +46,8 @@
   "dependencies": {
     "@analytics/storage-utils": "^0.2.12",
     "@analytics/type-utils": "^0.3.1",
-    "analytics-utils": "^1.0.2"
+    "analytics-utils": "^1.0.2",
+    "regenerator-runtime": "^0.13.9"
   },
   "devDependencies": {
     "concurrently": "^6.1.0",

--- a/packages/analytics-plugin-ownstats/package.json
+++ b/packages/analytics-plugin-ownstats/package.json
@@ -48,7 +48,10 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/preset-env": "^7.3.1"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-plugin-perfumejs/package.json
+++ b/packages/analytics-plugin-perfumejs/package.json
@@ -71,7 +71,10 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.4.5",
-    "@babel/preset-env": "^7.4.5"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-plugin-segment/package.json
+++ b/packages/analytics-plugin-segment/package.json
@@ -49,10 +49,11 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/preset-env": "^7.3.1"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
   },
   "dependencies": {
-    "analytics-node": "^3.5.0"
+    "analytics-node": "^3.5.0",
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-plugin-simple-analytics/package.json
+++ b/packages/analytics-plugin-simple-analytics/package.json
@@ -37,7 +37,10 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/preset-env": "^7.3.1"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-plugin-snowplow/package.json
+++ b/packages/analytics-plugin-snowplow/package.json
@@ -51,10 +51,11 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/preset-env": "^7.3.1"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
   },
   "dependencies": {
+    "regenerator-runtime": "^0.13.9",
     "snowplow-tracker": "^0.4.0"
   }
 }

--- a/packages/analytics-plugin-tab-events/package.json
+++ b/packages/analytics-plugin-tab-events/package.json
@@ -41,7 +41,10 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.4.5",
-    "@babel/preset-env": "^7.4.5"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-plugin-window-events/package.json
+++ b/packages/analytics-plugin-window-events/package.json
@@ -41,7 +41,10 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.4.5",
-    "@babel/preset-env": "^7.4.5"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-util-activity/package.json
+++ b/packages/analytics-util-activity/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@analytics/listener-utils": "^0.2.3",
-    "analytics-plugin-tab-events": "^0.2.0"
+    "analytics-plugin-tab-events": "^0.2.0",
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-util-forms/package.json
+++ b/packages/analytics-util-forms/package.json
@@ -48,6 +48,7 @@
     "watchlist": "^0.2.3"
   },
   "dependencies": {
-    "@analytics/type-utils": "^0.3.1"
+    "@analytics/type-utils": "^0.3.1",
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-util-listener/package.json
+++ b/packages/analytics-util-listener/package.json
@@ -51,6 +51,7 @@
     "watchlist": "^0.2.3"
   },
   "dependencies": {
-    "@analytics/type-utils": "^0.3.1"
+    "@analytics/type-utils": "^0.3.1",
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-util-params/package.json
+++ b/packages/analytics-util-params/package.json
@@ -55,15 +55,16 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "7.5.5",
-    "@babel/preset-env": "7.5.5",
-    "@babel/register": "^7.6.0",
-    "@babel/runtime": "7.5.5"
+    "@babel/core": "7.14.5",
+    "@babel/preset-env": "7.14.5",
+    "@babel/register": "^7.14.5",
+    "@babel/runtime": "7.14.5"
   },
   "dependencies": {
     "deepmerge": "^4.0.0",
     "qss": "^2.0.3",
     "query-string": "^6.8.3",
+    "regenerator-runtime": "^0.13.9",
     "search-params": "^2.1.3"
   }
 }

--- a/packages/analytics-util-queue/package.json
+++ b/packages/analytics-util-queue/package.json
@@ -44,5 +44,8 @@
     "npm-run-all": "^4.1.5",
     "uvu": "^0.5.1",
     "watchlist": "^0.2.3"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-util-router/package.json
+++ b/packages/analytics-util-router/package.json
@@ -41,7 +41,10 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.4.5",
-    "@babel/preset-env": "^7.4.5"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-util-scroll/package.json
+++ b/packages/analytics-util-scroll/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "@analytics/type-utils": "^0.3.1",
-    "analytics-utils": "^1.0.2"
+    "analytics-utils": "^1.0.2",
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-util-session/package.json
+++ b/packages/analytics-util-session/package.json
@@ -53,6 +53,7 @@
     "@analytics/cookie-utils": "^0.2.6",
     "@analytics/global-storage-utils": "^0.1.2",
     "@analytics/session-storage-utils": "^0.0.2",
-    "analytics-utils": "^1.0.2"
+    "analytics-utils": "^1.0.2",
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-util-storage-cookie/package.json
+++ b/packages/analytics-util-storage-cookie/package.json
@@ -49,6 +49,7 @@
     "watchlist": "^0.2.3"
   },
   "dependencies": {
-    "@analytics/global-storage-utils": "^0.1.2"
+    "@analytics/global-storage-utils": "^0.1.2",
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-util-storage-global/package.json
+++ b/packages/analytics-util-storage-global/package.json
@@ -48,5 +48,8 @@
     "microbundle": "^0.13.0",
     "servor": "^4.0.2",
     "watchlist": "^0.2.3"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-util-storage-local/package.json
+++ b/packages/analytics-util-storage-local/package.json
@@ -49,6 +49,7 @@
     "watchlist": "^0.2.3"
   },
   "dependencies": {
-    "@analytics/global-storage-utils": "^0.1.2"
+    "@analytics/global-storage-utils": "^0.1.2",
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-util-storage-remote/package.json
+++ b/packages/analytics-util-storage-remote/package.json
@@ -44,12 +44,13 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "devDependencies": {
-    "@babel/core": "^7.4.5",
-    "@babel/preset-env": "^7.4.5"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
   },
   "dependencies": {
     "@analytics/type-utils": "^0.3.1",
     "analytics-utils": "^1.0.2",
-    "cross-storage": "^1.0.0"
+    "cross-storage": "^1.0.0",
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-util-storage-session/package.json
+++ b/packages/analytics-util-storage-session/package.json
@@ -50,6 +50,7 @@
     "watchlist": "^0.2.3"
   },
   "dependencies": {
-    "@analytics/global-storage-utils": "^0.1.2"
+    "@analytics/global-storage-utils": "^0.1.2",
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-util-storage/package.json
+++ b/packages/analytics-util-storage/package.json
@@ -59,6 +59,7 @@
     "@analytics/cookie-utils": "^0.2.6",
     "@analytics/global-storage-utils": "^0.1.2",
     "@analytics/localstorage-utils": "^0.1.5",
-    "@analytics/type-utils": "^0.3.1"
+    "@analytics/type-utils": "^0.3.1",
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-util-types/package.json
+++ b/packages/analytics-util-types/package.json
@@ -46,5 +46,8 @@
     "microbundle": "^0.13.0",
     "servor": "^4.0.2",
     "watchlist": "^0.2.3"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/analytics-utils/package.json
+++ b/packages/analytics-utils/package.json
@@ -49,7 +49,8 @@
   },
   "dependencies": {
     "@analytics/type-utils": "^0.3.1",
-    "dlv": "^1.1.3"
+    "dlv": "^1.1.3",
+    "regenerator-runtime": "^0.13.9"
   },
   "peerDependencies": {
     "@types/dlv": "^1.0.0"

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -57,7 +57,8 @@
   "typings": "lib/types.d.ts",
   "dependencies": {
     "@analytics/core": "^0.10.13",
-    "@analytics/storage-utils": "^0.2.12"
+    "@analytics/storage-utils": "^0.2.12",
+    "regenerator-runtime": "^0.13.9"
   },
   "ava": {
     "files": [
@@ -74,12 +75,12 @@
     ]
   },
   "devDependencies": {
-    "@babel/core": "7.5.5",
-    "@babel/plugin-proposal-class-properties": "7.5.5",
-    "@babel/plugin-transform-runtime": "7.5.5",
-    "@babel/preset-env": "7.5.5",
-    "@babel/register": "7.5.5",
-    "@babel/runtime": "7.5.5",
+    "@babel/core": "7.14.5",
+    "@babel/plugin-proposal-class-properties": "7.14.5",
+    "@babel/plugin-transform-runtime": "7.14.5",
+    "@babel/preset-env": "7.14.5",
+    "@babel/register": "7.14.5",
+    "@babel/runtime": "7.14.5",
     "ava": "^2.2.0",
     "mkdirp": "^0.5.1",
     "npm-run-all": "^4.1.5",

--- a/packages/plugin-template/package.json
+++ b/packages/plugin-template/package.json
@@ -23,7 +23,10 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@babel/preset-env": "^7.3.1"
+    "@babel/core": "^7.14.5",
+    "@babel/preset-env": "^7.14.5"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.13.9"
   }
 }

--- a/packages/use-analytics/package.json
+++ b/packages/use-analytics/package.json
@@ -25,13 +25,14 @@
   "dependencies": {
     "hoist-non-react-statics": "^3.3.2",
     "mini-create-react-context": "^0.4.1",
+    "regenerator-runtime": "^0.13.9",
     "tiny-invariant": "^1.1.0"
   },
   "peerDependencies": {
     "react": ">=15"
   },
   "devDependencies": {
-    "@babel/plugin-proposal-decorators": "^7.8.3",
+    "@babel/plugin-proposal-decorators": "^7.14.5",
     "babel-eslint": "^10.0.3",
     "cross-env": "^7.0.2",
     "microbundle-crl": "^0.13.8",


### PR DESCRIPTION
I have set babel to the latest consistent version (7.14.5, 7.15.0 was partially built within the last few hours).  This did not fix the issue in analytics.js regarding the use of regeneratorRuntime's Function() call.  Explicitly setting the regeneratorRuntime in any package that has it forces for the updates that... should fix this.  

This ties to #192, hopefully resolving it... but I don't want to commit to it.  I'll keep plugging away.