### PR TITLE
Enrich page data when doing event tracking.

### DIFF
--- a/packages/analytics-core/src/index.js
+++ b/packages/analytics-core/src/index.js
@@ -408,7 +408,7 @@ function analytics(config = {}) {
         store.dispatch({
           type: EVENTS.trackStart,
           event: name,
-          properties: data,
+          properties: getPageData(data),
           options: opts,
           userId: getUserProp(ID, instance, payload),
           anonymousId: getUserProp(ANONID, instance, payload),


### PR DESCRIPTION
Hey there,

(I thought about creating a PR, as my comment in the issue #111 might be lost among the notifications.)

We require events to contain the originating page's information, and there are cases where an event is triggered right after a pageview is sent.

That can lead to race conditions, where the track event is called before the pageview has been finished, so the state doesn't contain the page information yet.

We thought about two different approaches to solving the problem. One would be to expose the getPageData helper so that it can be used inside our track method.

The other approach would be to always enrich track's data properties with page information, as prepared on this PR.

Do you guys think it's an acceptable solution, or is there a chance where it may lead to unexpected results?

Thanks a lot and looking forward to your response.