### PR TITLE
Allow more config options within Simple Analytics

### DIFF
--- a/packages/analytics-plugin-simple-analytics/README.md
+++ b/packages/analytics-plugin-simple-analytics/README.md
@@ -84,7 +84,7 @@ const analytics = Analytics({
 | `saGlobal` <br/>_optional_ - string       | Overwrite SA global for events. https://docs.simpleanalytics.com/events#the-variable-sa_event-is-already-used           |
 | `autoCollect` <br/>_optional_ - boolean   | Disable auto collect if needed. https://docs.simpleanalytics.com/trigger-custom-page-views#use-custom-collection-anyway |
 | `onloadCallback` <br/>_optional_ - string | Allow onload callback. https://docs.simpleanalytics.com/trigger-custom-page-views#use-custom-collection-anyway          |
-| `hostname` <br/>_optional_ - string       | Allow overwriting domain name. https://docs.simpleanalytics.com/dnt                                                     |
+| `hostname` <br/>_optional_ - string       | Allow overwriting domain name. https://docs.simpleanalytics.com/overwrite-domain-name                                                   |
 
 ## Additional examples
 

--- a/packages/analytics-plugin-simple-analytics/README.md
+++ b/packages/analytics-plugin-simple-analytics/README.md
@@ -75,11 +75,16 @@ const analytics = Analytics({
 ```
 
 ### Configuration options for browser
-
-| Option | description |
-|:---------------------------|:-----------|
-| `customDomain` <br/>_optional_ - string| Custom domain for simple analytics script.  https://docs.simpleanalytics.com/script |
-
+| Option                                    | description                                                                                                             |
+| :---------------------------------------- | :---------------------------------------------------------------------------------------------------------------------- |
+| `customDomain` <br/>_optional_ - string   | Custom domain for simple analytics script. https://docs.simpleanalytics.com/script                                      |
+| `collectDnt` <br/>_optional_ - boolean    | Allow collecting DNT visitors. https://docs.simpleanalytics.com/dnt                                                     |
+| `mode` <br/>_optional_ - string           | Allow hash mode. https://docs.simpleanalytics.com/hash-mode                                                             |
+| `ignorePages` <br/>_optional_ - string    | Add ignore pages. https://docs.simpleanalytics.com/ignore-pages                                                         |
+| `saGlobal` <br/>_optional_ - string       | Overwrite SA global for events. https://docs.simpleanalytics.com/events#the-variable-sa_event-is-already-used           |
+| `autoCollect` <br/>_optional_ - boolean   | Disable auto collect if needed. https://docs.simpleanalytics.com/trigger-custom-page-views#use-custom-collection-anyway |
+| `onloadCallback` <br/>_optional_ - string | Allow onload callback. https://docs.simpleanalytics.com/trigger-custom-page-views#use-custom-collection-anyway          |
+| `hostname` <br/>_optional_ - string       | Allow overwriting domain name. https://docs.simpleanalytics.com/dnt                                                     |
 
 ## Additional examples
 

--- a/packages/analytics-plugin-simple-analytics/src/browser.js
+++ b/packages/analytics-plugin-simple-analytics/src/browser.js
@@ -72,13 +72,12 @@ export default function simpleAnalyticsPlugin(pluginConfig = {}) {
         throw new Error(`${src} failed to load.`)
       })
     },
-    /* https://docs.simpleanalytics.com/events
+    /* https://docs.simpleanalytics.com/events */
     track: ({ payload }) => {
       var saEventFunction = window[config.saGlobal] || window.sa_event || window.sa
       if (!saEventFunction) return false
       saEventFunction(payload.event)
     },
-    */
     /* Verify script loaded */
     loaded: () => {
       return !!isLoaded

--- a/packages/analytics-plugin-simple-analytics/src/browser.js
+++ b/packages/analytics-plugin-simple-analytics/src/browser.js
@@ -31,7 +31,7 @@ export default function simpleAnalyticsPlugin(pluginConfig = {}) {
       script.src = `${src}`
 
       // Allow overwriting domain name
-      // https://docs.simpleanalytics.com/dnt
+      // https://docs.simpleanalytics.com/overwrite-domain-name
       if (config.hostname) script.dataset.hostname = config.hostname;
 
       // Allow collecting DNT visitors

--- a/packages/analytics-plugin-simple-analytics/src/browser.js
+++ b/packages/analytics-plugin-simple-analytics/src/browser.js
@@ -4,8 +4,15 @@
  * Simple Analytics plugin
  * @link https://getanalytics.io/plugins/simple-analytics/
  * @link https://docs.simpleanalytics.com/
- * @param {object}  [pluginConfig] - Plugin settings
- * @param {string} [pluginConfig.customDomain] - Custom domain for simple analytics script.  https://docs.simpleanalytics.com/script
+ * @param {object} [pluginConfig] - Plugin settings
+ * @param {string} [pluginConfig.customDomain] - Custom domain for simple analytics script. https://docs.simpleanalytics.com/script
+ * @param {string} [pluginConfig.hostname] - Allow overwriting domain name https://docs.simpleanalytics.com/overwrite-domain-name
+ * @param {string} [pluginConfig.collectDnt] - Allow collecting DNT visitors https://docs.simpleanalytics.com/dnt
+ * @param {string} [pluginConfig.mode] - Allow hash mode https://docs.simpleanalytics.com/hash-mode
+ * @param {string} [pluginConfig.ignorePages] - Add ignore pages https://docs.simpleanalytics.com/ignore-pages
+ * @param {string} [pluginConfig.saGlobal] - Overwrite SA global for events https://docs.simpleanalytics.com/events#the-variable-sa_event-is-already-used
+ * @param {string} [pluginConfig.autoCollect] - Overwrite SA global for events https://docs.simpleanalytics.com/trigger-custom-page-views#use-custom-collection-anyway
+ * @param {string} [pluginConfig.onloadCallback] -  Allow onload callback https://docs.simpleanalytics.com/trigger-custom-page-views#use-custom-collection-anyway
  * @return {object} Analytics plugin
  * @example
  *

--- a/packages/analytics-plugin-simple-analytics/src/browser.js
+++ b/packages/analytics-plugin-simple-analytics/src/browser.js
@@ -1,4 +1,4 @@
-/* global sa */
+/* global sa, sa_event */
 
 /**
  * Simple Analytics plugin
@@ -19,12 +19,44 @@ export default function simpleAnalyticsPlugin(pluginConfig = {}) {
     config: pluginConfig,
     // https://docs.simpleanalytics.com/script
     initialize: ({ config }) => {
+      // Allow for a custom domain
+      // https://docs.simpleanalytics.com/bypass-ad-blockers
       const domain = config.customDomain || 'scripts.simpleanalyticscdn.com'
+
+      // Setup script
       const src = `https://${domain}/latest.js`
       const script = document.createElement('script')
       script.type = 'text/javascript'
       script.async = true
       script.src = `${src}`
+
+      // Allow overwriting domain name
+      // https://docs.simpleanalytics.com/dnt
+      if (config.hostname) script.dataset.hostname = config.hostname;
+
+      // Allow collecting DNT visitors
+      // https://docs.simpleanalytics.com/dnt
+      if (config.collectDnt) script.dataset.collectDnt = 'true';
+
+      // Allow hash mode
+      // https://docs.simpleanalytics.com/hash-mode
+      if (config.mode) script.dataset.mode = config.mode;
+
+      // Add ignore pages
+      // https://docs.simpleanalytics.com/ignore-pages
+      if (config.ignorePages) script.dataset.ignorePages = config.ignorePages;
+
+      // Overwrite SA global for events
+      // https://docs.simpleanalytics.com/events#the-variable-sa_event-is-already-used
+      if (config.saGlobal) script.dataset.saGlobal = config.saGlobal;
+
+      // Disable auto collect if needed
+      // https://docs.simpleanalytics.com/trigger-custom-page-views#use-custom-collection-anyway
+      if (config.autoCollect) script.dataset.autoCollect = config.autoCollect;
+
+      // Allow onload callback
+      // https://docs.simpleanalytics.com/trigger-custom-page-views#use-custom-collection-anyway
+      if (config.onloadCallback) script.onload = config.onloadCallback;
 
       // Append the script to the DOM
       const el = document.getElementsByTagName('script')[0]
@@ -39,12 +71,12 @@ export default function simpleAnalyticsPlugin(pluginConfig = {}) {
       script.addEventListener('error', () => {
         throw new Error(`${src} failed to load.`)
       })
-      // Todo load analytics script via users subdomain for custom event tracking
     },
     /* https://docs.simpleanalytics.com/events
     track: ({ payload }) => {
-      if (typeof sa === 'undefined') return false
-      sa(payload.event)
+      var saEventFunction = window[config.saGlobal] || window.sa_event || window.sa
+      if (!saEventFunction) return false
+      saEventFunction(payload.event)
     },
     */
     /* Verify script loaded */


### PR DESCRIPTION
Extra options:

| Option                                    | description                                                                                                             |
| :---------------------------------------- | :---------------------------------------------------------------------------------------------------------------------- |
| `customDomain` <br/>_optional_ - string   | Custom domain for simple analytics script. https://docs.simpleanalytics.com/script                                      |
| `collectDnt` <br/>_optional_ - boolean    | Allow collecting DNT visitors. https://docs.simpleanalytics.com/dnt                                                     |
| `mode` <br/>_optional_ - string           | Allow hash mode. https://docs.simpleanalytics.com/hash-mode                                                             |
| `ignorePages` <br/>_optional_ - string    | Add ignore pages. https://docs.simpleanalytics.com/ignore-pages                                                         |
| `saGlobal` <br/>_optional_ - string       | Overwrite SA global for events. https://docs.simpleanalytics.com/events#the-variable-sa_event-is-already-used           |
| `autoCollect` <br/>_optional_ - boolean   | Disable auto collect if needed. https://docs.simpleanalytics.com/trigger-custom-page-views#use-custom-collection-anyway |
| `onloadCallback` <br/>_optional_ - string | Allow onload callback. https://docs.simpleanalytics.com/trigger-custom-page-views#use-custom-collection-anyway          |
| `hostname` <br/>_optional_ - string       | Allow overwriting domain name. https://docs.simpleanalytics.com/overwrite-domain-name                                   |
