### PR TITLE
If no segment, return on analytics.reset method

### DIFF
--- a/packages/analytics-plugin-segment/src/browser.js
+++ b/packages/analytics-plugin-segment/src/browser.js
@@ -158,6 +158,7 @@ function segmentPlugin(pluginConfig = {}) {
     },
     /* Remove segment cookies on analytics.reset */
     reset: () => {
+      if (typeof analytics === 'undefined') return
       analytics.reset();
     },
     /* Sync id when ready */


### PR DESCRIPTION
## Motivation

We started seen the error  `ReferenceError: analytics is not defined` when calling `analytics.reset()`.

## Proposed Solution

Seems that the reset method is missing the early return when segment is not available.