### PR TITLE
Update FullStory `window._fs_host` Value to prevent CORS Error

### DIFF
--- a/packages/analytics-plugin-fullstory/src/browser.js
+++ b/packages/analytics-plugin-fullstory/src/browser.js
@@ -54,7 +54,7 @@ function fullStoryPlugin(pluginConfig = {}) {
       }
 
       window._fs_debug = config.debug
-      window._fs_host = 'www.fullstory.com'
+      window._fs_host = 'fullstory.com'
       window._fs_org = config.org
       window._fs_namespace = 'FS'
 


### PR DESCRIPTION
Fixes #264 

Remove `www` from `window._fs_host` value to prevent CORS errors.