### PR TITLE
Pinpoint document referrer send null instead of empty string

### DIFF
--- a/packages/analytics-plugin-aws-pinpoint/src/browser.js
+++ b/packages/analytics-plugin-aws-pinpoint/src/browser.js
@@ -177,7 +177,7 @@ function awsPinpointPlugin(pluginConfig = {}) {
             userId: instance.user('userId'),
             hash: window.location.hash,
             path: window.location.pathname,
-            referrer: document.referrer,
+            referrer: document.referrer || null,
             search: window.location.search,
             title: document.title,
             host: window.location.hostname,


### PR DESCRIPTION
## Description

Add `||` operator to send a null value instead of an empty string. If you think there should be a valid reason for sending the empty string instead of a null value, please let me know. I think it just makes more sense to store a `NULL` value instead of an `""` in the database.

## Links

Here's a link to the issue I created. https://github.com/DavidWells/analytics/issues/267