### PR TITLE
fix: pre-installed gtag causes analytics.js plugin to not initialize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ queues
 TODO.md
 types/
 misc.js
+
+### VisualStudioCode ###
+.vscode/*

--- a/packages/analytics-plugin-google-analytics/src/browser.js
+++ b/packages/analytics-plugin-google-analytics/src/browser.js
@@ -84,11 +84,13 @@ function googleAnalytics(pluginConfig = {}) {
     initialize: ({ config, instance }) => {
       const { dataLayerName, customScriptSrc, gtagName, gtagConfig, debug } = config
       /* Inject google gtag.js script if not found */
-      if (!scriptLoaded(customScriptSrc || gtagScriptSource)) {
-        const customLayerName = dataLayerName ? `&l=${dataLayerName}` : ''
+      /* If other gtags are loaded already, add ours anyway */
+      const customLayerName = dataLayerName ? `&l=${dataLayerName}` : "";
+      const src = customScriptSrc || `${gtagScriptSource}?id=${measurementIds[0]}${customLayerName}`;
+      if (!scriptLoaded(src)) {
         const script = document.createElement('script')
         script.async = true
-        script.src = customScriptSrc || `${gtagScriptSource}?id=${measurementIds[0]}${customLayerName}`
+        script.src = src
         document.body.appendChild(script)
       }
       /* Set gtag and datalayer */


### PR DESCRIPTION
It's very common for other gtags (from universal analytics, google ads, etc) to already be loaded before analytics.js loads gtag. Before this fix, they would cause analytics.js not to load gtag in the initialize function, thus preventing google analytics from firing.

This fix checks if OUR gtag is loaded already, instead of checking if any gtag is loaded.