### PR TITLE
Add customScriptSrc for customer.io (browser)

### DIFF
--- a/packages/analytics-plugin-customerio/README.md
+++ b/packages/analytics-plugin-customerio/README.md
@@ -113,6 +113,7 @@ const analytics = Analytics({
 |:---------------------------|:-----------|
 | `siteId` <br/>**required** - string| Customer.io site Id for client side tracking |
 | `disableAnonymousTraffic` <br/>_optional_ - boolean| Disable anonymous events from firing |
+| `customScriptSrc` <br/>_optional_ - string| Load Customer.io script from custom source |
 
 ## Server-side usage
 

--- a/packages/analytics-plugin-customerio/src/browser.js
+++ b/packages/analytics-plugin-customerio/src/browser.js
@@ -6,6 +6,7 @@
  * @link https://customer.io/docs/javascript-quick-start
  * @param {object} pluginConfig - Plugin settings
  * @param {string} pluginConfig.siteId - Customer.io site Id for client side tracking
+ * @param {string} pluginConfig.customScriptSrc - Custom URL for customer.io script, if proxying calls
  * @param {boolean} [pluginConfig.disableAnonymousTraffic] -  Disable anonymous events from firing
  * @return {object} Analytics plugin
  * @example
@@ -22,7 +23,7 @@ function customerIOPlugin(pluginConfig = {}) {
     name: 'customerio',
     config: pluginConfig,
     initialize: ({ config }) => {
-      const { siteId } = config
+      const { siteId, customScriptSrc } = config
       if (!siteId) {
         throw new Error('No customer.io siteId defined')
       }
@@ -42,7 +43,7 @@ function customerIOPlugin(pluginConfig = {}) {
           t.async = true
           t.id = 'cio-tracker'
           t.setAttribute('data-site-id', siteId)
-          t.src = 'https://assets.customer.io/assets/track.js'
+          t.src = customScriptSrc || 'https://assets.customer.io/assets/track.js'
           s.parentNode.insertBefore(t, s)
         })()
       }

--- a/packages/analytics-plugin-customerio/src/browser.js
+++ b/packages/analytics-plugin-customerio/src/browser.js
@@ -6,7 +6,7 @@
  * @link https://customer.io/docs/javascript-quick-start
  * @param {object} pluginConfig - Plugin settings
  * @param {string} pluginConfig.siteId - Customer.io site Id for client side tracking
- * @param {string} pluginConfig.customScriptSrc - Custom URL for customer.io script, if proxying calls
+ * @param {string} pluginConfig.customScriptSrc - Load Customer.io script from custom source
  * @param {boolean} [pluginConfig.disableAnonymousTraffic] -  Disable anonymous events from firing
  * @return {object} Analytics plugin
  * @example

--- a/site/main/source/plugins/customerio.md
+++ b/site/main/source/plugins/customerio.md
@@ -110,6 +110,7 @@ const analytics = Analytics({
 |:---------------------------|:-----------|
 | `siteId` <br/>**required** - string| Customer.io site Id for client side tracking |
 | `disableAnonymousTraffic` <br/>_optional_ - boolean| Disable anonymous events from firing |
+| `customScriptSrc` <br/>_optional_ - string| Load Customer.io script from custom source |
 
 ## Server-side usage
 


### PR DESCRIPTION
This PR adds `customScriptSrc` to the customer.io browser plugin. 

It allows loading in the customer.io script from a custom source. I've added the necessary docs too.