### PR TITLE
rcmaples/fullstory-updates

### DIFF
--- a/packages/analytics-plugin-fullstory/README.md
+++ b/packages/analytics-plugin-fullstory/README.md
@@ -12,6 +12,8 @@ FullStory is a tool that tracks user behavior in your application. User sessions
 
 This analytics plugin will add the FullStory javascript library to your app & send custom events into FullStory.
 
+For more information on FullStory's official browser package, you can check out [the official FullStory Browser SDK on NPM](https://www.npmjs.com/package/@fullstory/browser).
+
 [View the docs](https://getanalytics.io/plugins/fullstory/)
 
 <!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click to expand) -->

--- a/packages/analytics-plugin-fullstory/README.md
+++ b/packages/analytics-plugin-fullstory/README.md
@@ -225,11 +225,11 @@ Below are additional implementation examples.
 
 ## Formatting payloads
 
-Full story requires [specific naming conventions](https://help.fullstory.com/hc/en-us/articles/360020623234) for tracking.
+FullStory requires [specific naming conventions](https://help.fullstory.com/hc/en-us/articles/360020623234) for tracking.
 
 We have taken the liberty of making this easier to use with this plugin. 🎉
 
-Values sent to Full Story will be automatically converted into a values their API will understand.
+Values sent to FullStory will be automatically converted into a values their API will understand.
 
 **Example**
 
@@ -251,4 +251,4 @@ FS.event('itemPurchased', {
 })
 ```
 
-This will ensure data flows into full story correctly.
+This will ensure data flows into FullStory correctly.

--- a/packages/analytics-plugin-fullstory/package.json
+++ b/packages/analytics-plugin-fullstory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@analytics/fullstory",
-  "version": "0.2.4",
-  "description": "FullStory plugin for 'analytics' module",
+  "version": "0.2.5",
+  "description": "Unofficial FullStory plugin for 'analytics' module",
   "projectMeta": {
     "provider": {
       "name": "FullStory",

--- a/packages/analytics-plugin-fullstory/src/browser.js
+++ b/packages/analytics-plugin-fullstory/src/browser.js
@@ -53,20 +53,28 @@ function fullStoryPlugin(pluginConfig = {}) {
         }, 0)
       }
 
-      window._fs_debug = config.debug
-      window._fs_host = 'www.fullstory.com'
-      window._fs_org = config.org
-      window._fs_namespace = 'FS'
+      window._fs_host = 'fullstory.com';
+      window._fs_script = 'edge.fullstory.com/s/fs.js';
+      window._fs_org = config.org;
+      window._fs_namespace = 'FS';
 
       /* eslint-disable */
       ;(function(m,n,e,t,l,o,g,y){
         if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
         g=m[e]=function(a,b,s){g.q?g.q.push([a,b,s]):g._api(a,b,s);};g.q=[];
+        o=n.createElement(t);o.async=1;o.crossOrigin='anonymous';o.src='https://'+_fs_script;
+        y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
         g.identify=function(i,v,s){g(l,{uid:i},s);if(v)g(l,v,s)};g.setUserVars=function(v,s){g(l,v,s)};g.event=function(i,v,s){g('event',{n:i,p:v},s)};
+        g.anonymize=function(){g.identify(!!0)};
         g.shutdown=function(){g("rec",!1)};g.restart=function(){g("rec",!0)};
+        g.log = function(a,b){g("log",[a,b])};
         g.consent=function(a){g("consent",!arguments.length||a)};
         g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
         g.clearUserCookie=function(){};
+        g.setVars=function(n, p){g('setVars',[n,p]);};
+        g._w={};y='XMLHttpRequest';g._w[y]=m[y];y='fetch';g._w[y]=m[y];
+        if(m[y])m[y]=function(){return g._w[y].apply(this,arguments)};
+        g._v="1.3.0";
       })(window,document,window['_fs_namespace'],'script','user');
       /* eslint-enable */
     },

--- a/packages/analytics-plugin-fullstory/src/browser.js
+++ b/packages/analytics-plugin-fullstory/src/browser.js
@@ -53,6 +53,7 @@ function fullStoryPlugin(pluginConfig = {}) {
         }, 0)
       }
 
+      window._fs_debug = config.debug
       window._fs_host = 'fullstory.com';
       window._fs_script = 'edge.fullstory.com/s/fs.js';
       window._fs_org = config.org;

--- a/site/main/source/plugins/fullstory.md
+++ b/site/main/source/plugins/fullstory.md
@@ -219,11 +219,11 @@ Below are additional implementation examples.
 
 ## Formatting payloads
 
-Full story requires [specific naming conventions](https://help.fullstory.com/hc/en-us/articles/360020623234) for tracking.
+FullStory requires [specific naming conventions](https://help.fullstory.com/hc/en-us/articles/360020623234) for tracking.
 
 We have taken the liberty of making this easier to use with this plugin. 🎉
 
-Values sent to Full Story will be automatically converted into a values their API will understand.
+Values sent to FullStory will be automatically converted into a values their API will understand.
 
 **Example**
 
@@ -245,4 +245,4 @@ FS.event('itemPurchased', {
 })
 ```
 
-This will ensure data flows into full story correctly.
+This will ensure data flows into FullStory correctly.

--- a/site/main/source/plugins/fullstory.md
+++ b/site/main/source/plugins/fullstory.md
@@ -4,11 +4,13 @@ subTitle: Using the FullStory analytics plugin
 description: Integrate FullStory visitor tracking with the open source analytics module
 ---
 
-Integration with [FullStory](https://www.fullstory.com/) for [analytics](https://www.npmjs.com/package/analytics)
+Unofficial Integration with [FullStory](https://www.fullstory.com/) for [analytics](https://www.npmjs.com/package/analytics)
 
 FullStory is a tool that tracks user behavior in your application. User sessions are recorded and can be played back allowing developers and product owners to identify areas for improvement in their software.
 
 This analytics plugin will add the FullStory javascript library to your app & send custom events into FullStory.
+
+For more information on FullStory's official browser package, you can check out [the official FullStory Browser SDK on NPM](https://www.npmjs.com/package/@fullstory/browser).
 
 <!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click to expand) -->
 <details>


### PR DESCRIPTION
Hi! I'm RC and I manage the Support Engineering team at FullStory. We recently had a case come in from someone using your library. We noticed that the code related to our snippet was quite out of date. While we strive to maintain backwards compatibility with previous versions of our capture snippet, there are important updates to the snippet that this PR adds and updated the window vars to match. 

Updates: 
Updated snippet and window variables in `packages/analytics-plugin-fullstory/src/browser.js`

Added callouts that this is an unofficial FullStory plugin and adjusted references to "FullStory" in the following files:
`/analytics-plugin-fullstory/package.json`
`/analytics-plugin-fullstory/README.md`
`site/main/source/plugins/fullstory.md`
It might be worth adding a disclaimer that FullStory may be unable to troubleshoot any issues experienced with FullStory while using this library.

Also provided links to the official npm package for posterity.

Let me know if these changes look good; would love to get folks using your library onto the most recent version of our snippet!