### PR TITLE
update docs to reflect correct `deleteCookie` exported function name

### DIFF
--- a/site/main/source/utils/cookies.md
+++ b/site/main/source/utils/cookies.md
@@ -8,7 +8,7 @@ A tiny cookie utility library with fallbacks in <!-- AUTO-GENERATED-CONTENT:STAR
 
 This module will automatically fail back to global window storage if `cookies` are not available.
 
-Exposes `hasCookies`, `getCookie`, `setCookie`, & `removeCookie` functions.
+Exposes `hasCookies`, `getCookie`, `setCookie`, & `deleteCookie` functions.
 
 [See live demo](https://utils-cookies.netlify.app/).
 


### PR DESCRIPTION
`removeCookie` is mentioned here but isn't actually exported - it should be `deleteCookie`