### PR TITLE
Doc: replace deleteCookie for removeCookie

### DIFF
--- a/packages/analytics-util-storage-cookie/README.md
+++ b/packages/analytics-util-storage-cookie/README.md
@@ -63,12 +63,12 @@ setCookie('test', 'a')
 setCookie('test', 'a', 60*60*24, '/api', '*.example.com', true)
 ```
 
-## `deleteCookie`
+## `removeCookie`
 
-Delete a cookie.
+Remove a cookie.
 
 ```js
-import { deleteCookie } from '@analytics/cookie-utils'
+import { removeCookie } from '@analytics/cookie-utils'
 
-deleteCookie('cookie-key')
+removeCookie('cookie-key')
 ```

--- a/site/main/source/utils/cookies.md
+++ b/site/main/source/utils/cookies.md
@@ -60,12 +60,12 @@ setCookie('test', 'a')
 setCookie('test', 'a', 60*60*24, '/api', '*.example.com', true)
 ```
 
-## `deleteCookie`
+## `removeCookie`
 
-Delete a cookie.
+Remove a cookie.
 
 ```js
-import { deleteCookie } from '@analytics/cookie-utils'
+import { removeCookie } from '@analytics/cookie-utils'
 
-deleteCookie('cookie-key')
+removeCookie('cookie-key')
 ```


### PR DESCRIPTION
It seems that the deleteCookie method was replaced by removeCookie. Fix documentation.