### PR TITLE
Mark analytics.plugins.disable callback as optional

### DIFF
--- a/packages/analytics-core/src/index.js
+++ b/packages/analytics-core/src/index.js
@@ -222,7 +222,7 @@ function analytics(config = {}) {
      * Disable analytics plugin
      * @typedef {Function} DisablePlugin
      * @param  {string|string[]} plugins - name of integration(s) to disable
-     * @param  {Function} callback - callback after disable runs
+     * @param  {Function} [callback] - callback after disable runs
      * @returns {Promise}
      * @example
      *


### PR DESCRIPTION
Noticed that this is required in the typescript types, but it should be optional from what I can tell.
