### PR TITLE
Clean up README for analytics.once()

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ removeListener()
 
 ### analytics.once
 
-Attach a handler function to an event and only trigger it only once.
+Attach a handler function to an event and only trigger it once.
 
 **Arguments**
 
@@ -491,9 +491,9 @@ Attach a handler function to an event and only trigger it only once.
 **Example**
 
 ```js
-// Fire function only once 'track'
+// Fire function only once per 'track'
 analytics.once('track', ({ payload }) => {
-  console.log('This will only triggered once when analytics.track() fires')
+  console.log('This is only triggered once when analytics.track() fires')
 })
 
 // Remove listener before it is called


### PR DESCRIPTION
Just a tiny PR to remove a repeated word and clean up the description for analytics.once()