### PR TITLE
Don't assume gtag is setup if dataLayer is

### DIFF
--- a/packages/analytics-plugin-google-analytics/src/browser.js
+++ b/packages/analytics-plugin-google-analytics/src/browser.js
@@ -93,14 +93,17 @@ function googleAnalytics(pluginConfig = {}) {
         script.src = src
         document.body.appendChild(script)
       }
-      /* Set gtag and datalayer */
+      /* Set up gtag and datalayer */
       if (!window[dataLayerName]) {
         window[dataLayerName] = window[dataLayerName] || []
+      }
+      if (!window[gtagName]) {
         window[gtagName] = function () {
           window[dataLayerName].push(arguments)
         }
-        window[gtagName]('js', new Date())
       }
+      window[gtagName]('js', new Date())
+
       // Initialize tracker instances on page
       let gtagConf = {
         ...defaultGtagConf,


### PR DESCRIPTION
If an analytics lib users pushes something onto the data layer prior to initializing analytics, and doesn't setup the gtag function, the library shouldn't error out due to missing gtag function.