### PR TITLE
Add analytics-plugin-conscia to list of external plugins

### DIFF
--- a/external-plugins.json
+++ b/external-plugins.json
@@ -64,5 +64,11 @@
     "name": "RudderStack",
     "url": "https://www.npmjs.com/package/begrowth-analytics-rudderstack",
     "description": "Adds Analytics support for RudderStack"
+  },
+  {
+    "name": "Conscia",
+    "url": "https://www.npmjs.com/package/analytics-plugin-conscia",
+    "repo": "https://github.com/conscia/analytics-plugin-conscia",
+    "description": "Adds Analytics support for conscia.ai"
   }
 ]


### PR DESCRIPTION
analytics-plugin-conscia enables analytics events to be submitted to the Conscia event tracking API