### PR TITLE
GA trackingId -> measurementIds

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![npm](https://img.shields.io/npm/dm/analytics?style=flat-square) ![npm bundle size](https://img.shields.io/bundlephobia/minzip/analytics?style=flat-square) ![GitHub](https://img.shields.io/github/license/davidwells/analytics?style=flat-square)
 
-A lightweight analytics abstraction library for tracking page views, custom events, & identify visitors. 
+A lightweight analytics abstraction library for tracking page views, custom events, & identify visitors.
 
 Designed to work with any [third-party analytics tool](https://getanalytics.io/plugins/) or your own backend.
 
@@ -109,7 +109,7 @@ const analytics = Analytics({
   version: 100,
   plugins: [
     googleAnalytics({
-      trackingId: 'UA-121991291',
+      measurementIds: 'UA-121991291',
     }),
     customerIo({
       siteId: '123-xyz'
@@ -150,7 +150,7 @@ analytics.identify('user-id-xyz', {
     version: 100,
     plugins: [
       googleAnalytics({
-        trackingId: 'UA-121991291',
+        measurementIds: 'UA-121991291',
       }),
       customerIo({
         siteId: '123-xyz'
@@ -592,7 +592,7 @@ analytics.storage.removeItem('storage_key')
 
 ### analytics.plugins
 
-Async Management methods for plugins. 
+Async Management methods for plugins.
 
 This is also where [custom methods](https://bit.ly/329vFXy) are loaded into the instance.
 
@@ -903,7 +903,7 @@ const analytics = Analytics({
     // include myPlugin
     myPlugin(),
     customerIoPlugin({
-      trackingId: '1234'
+      measurementIds: '1234'
     })
     ...otherPlugins
   ]

--- a/examples/demo/src/utils/analytics/basic.js
+++ b/examples/demo/src/utils/analytics/basic.js
@@ -2,7 +2,7 @@ import Analytics from 'analytics'
 import googleAnalytics from '@analytics/google-analytics'
 
 const customGA = googleAnalytics({
-  trackingId: process.env.REACT_APP_GOOGLE_ANALYTICS_ID,
+  measurementIds: process.env.REACT_APP_GOOGLE_ANALYTICS_ID,
   enabled: true
 })
 

--- a/examples/demo/src/utils/analytics/disabled-plugins.js
+++ b/examples/demo/src/utils/analytics/disabled-plugins.js
@@ -2,7 +2,7 @@ import Analytics from 'analytics'
 import googleAnalytics from '@analytics/google-analytics'
 
 const customGA = googleAnalytics({
-  trackingId: process.env.REACT_APP_GOOGLE_ANALYTICS_ID,
+  measurementIds: process.env.REACT_APP_GOOGLE_ANALYTICS_ID,
 })
 
 /* initialize analytics and load plugins */

--- a/examples/demo/src/utils/analytics/example-2.js
+++ b/examples/demo/src/utils/analytics/example-2.js
@@ -5,7 +5,7 @@ import exampleProviderPlugin from './plugins/provider-example'
 
 const googleAnalyticsInstanceTwo = {
   ...googleAnalytics({
-    trackingId: 'UA-126647663-6',
+    measurementIds: 'UA-126647663-6',
     instanceName: 'two'
   }),
   ...{
@@ -34,7 +34,7 @@ const analytics = Analytics({
       settingOne: 'xyz'
     }),
     googleAnalytics({
-      trackingId: process.env.REACT_APP_GOOGLE_ANALYTICS_ID,
+      measurementIds: process.env.REACT_APP_GOOGLE_ANALYTICS_ID,
       // Custom dimensions mapping example
       customDimensions: {
         baz: 'dimension1',

--- a/examples/demo/src/utils/analytics/example-3.js
+++ b/examples/demo/src/utils/analytics/example-3.js
@@ -116,7 +116,7 @@ const analytics = Analytics({
     }),
     */
     googleAnalytics({
-      trackingId: process.env.REACT_APP_GOOGLE_ANALYTICS_ID,
+      measurementIds: process.env.REACT_APP_GOOGLE_ANALYTICS_ID,
     }),
     reduxPlugin,
     /*{

--- a/examples/preact/src/analytics.js
+++ b/examples/preact/src/analytics.js
@@ -6,7 +6,7 @@ const analytics = Analytics({
   debug: true,
   plugins: [
     googleAnalytics({
-      trackingId: 'UA-126647663-2',
+      measurementIds: 'UA-126647663-2',
     }),
   ]
 })

--- a/examples/using-perfumejs/src/App.js
+++ b/examples/using-perfumejs/src/App.js
@@ -23,7 +23,7 @@ const analytics = Analytics({
     // Custom plugins to now send perf data to
     customAnalyticsPlugin,
     googleAnalytics({
-      trackingId: 'UA-126647663-7'
+      measurementIds: 'UA-126647663-7'
     }),
     perfumePlugin({
       category: 'perf',

--- a/examples/vanilla-html/README.md
+++ b/examples/vanilla-html/README.md
@@ -18,7 +18,7 @@
     version: 100,
     plugins: [
       analyticsGa({
-        trackingId: 'UA-126647663-3'
+        measurementIds: 'UA-126647663-3'
       })
       // ... add other plugins
     ]

--- a/examples/vanilla-html/index.html
+++ b/examples/vanilla-html/index.html
@@ -13,7 +13,7 @@
         plugins: [
           // attach google analytics plugin
           analyticsGa.default({
-            trackingId: 'UA-126647663-3'
+            measurementIds: 'UA-126647663-3'
           })
           // ... add any other third party analytics plugins
         ]

--- a/examples/vue/src/analytics.js
+++ b/examples/vue/src/analytics.js
@@ -6,7 +6,7 @@ const analytics = Analytics({
   debug: true,
   plugins: [
     googleAnalytics({
-      trackingId: 'UA-126647663-5',
+      measurementIds: 'UA-126647663-5',
       autoTrack: true,
     }),
   ]

--- a/packages/analytics-core/README.md
+++ b/packages/analytics-core/README.md
@@ -2,7 +2,7 @@
 
 ![npm](https://img.shields.io/npm/dm/analytics?style=flat-square) ![npm bundle size](https://img.shields.io/bundlephobia/minzip/analytics?style=flat-square) ![GitHub](https://img.shields.io/github/license/davidwells/analytics?style=flat-square)
 
-A lightweight analytics abstraction library for tracking page views, custom events, & identify visitors. 
+A lightweight analytics abstraction library for tracking page views, custom events, & identify visitors.
 
 Designed to work with any [third-party analytics tool](https://getanalytics.io/plugins/) or your own backend.
 
@@ -107,7 +107,7 @@ const analytics = Analytics({
   version: 100,
   plugins: [
     googleAnalytics({
-      trackingId: 'UA-121991291',
+      measurementIds: 'UA-121991291',
     }),
     customerIo({
       siteId: '123-xyz'
@@ -148,7 +148,7 @@ analytics.identify('user-id-xyz', {
     version: 100,
     plugins: [
       googleAnalytics({
-        trackingId: 'UA-121991291',
+        measurementIds: 'UA-121991291',
       }),
       customerIo({
         siteId: '123-xyz'
@@ -590,7 +590,7 @@ analytics.storage.removeItem('storage_key')
 
 ### analytics.plugins
 
-Async Management methods for plugins. 
+Async Management methods for plugins.
 
 This is also where [custom methods](https://bit.ly/329vFXy) are loaded into the instance.
 
@@ -901,7 +901,7 @@ const analytics = Analytics({
     // include myPlugin
     myPlugin(),
     customerIoPlugin({
-      trackingId: '1234'
+      measurementIds: '1234'
     })
     ...otherPlugins
   ]

--- a/packages/analytics-plugin-event-validation/README.md
+++ b/packages/analytics-plugin-event-validation/README.md
@@ -104,7 +104,7 @@ const analytics = Analytics({
   plugins: [
     customValidationPlugin,
     googleAnalytics({
-      trackingId: 'UA-121991123',
+      measurementIds: 'UA-121991123',
     })
   ]
 })

--- a/packages/analytics-plugin-google-analytics/README.md
+++ b/packages/analytics-plugin-google-analytics/README.md
@@ -262,7 +262,7 @@ const analytics = Analytics({
     }),
     /* Load Google Analytics v3 */
     googleAnalyticsV3Plugin({
-      trackingId: 'UA-11111111-2',
+      measurementIds: 'UA-11111111-2',
     }),
   ],
 })

--- a/packages/analytics-plugin-perfumejs/README.md
+++ b/packages/analytics-plugin-perfumejs/README.md
@@ -59,7 +59,7 @@ const analytics = Analytics({
   plugins: [
     // Attach Google analytics
     googleAnalytics({
-      trackingId: 'UA-12341131-6',
+      measurementIds: 'UA-12341131-6',
       instanceName: 'two'
     })
     // Attach Hubspot analytics
@@ -224,7 +224,7 @@ const analytics = Analytics({
   plugins: [
     // Attach Google analytics
     googleAnalytics({
-      trackingId: 'UA-12341131-6',
+      measurementIds: 'UA-12341131-6',
       instanceName: 'two'
     })
     // Attach Hubspot analytics

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -2,7 +2,7 @@
 
 ![npm](https://img.shields.io/npm/dm/analytics?style=flat-square) ![npm bundle size](https://img.shields.io/bundlephobia/minzip/analytics?style=flat-square) ![GitHub](https://img.shields.io/github/license/davidwells/analytics?style=flat-square)
 
-A lightweight analytics abstraction library for tracking page views, custom events, & identify visitors. 
+A lightweight analytics abstraction library for tracking page views, custom events, & identify visitors.
 
 Designed to work with any [third-party analytics tool](https://getanalytics.io/plugins/) or your own backend.
 
@@ -107,7 +107,7 @@ const analytics = Analytics({
   version: 100,
   plugins: [
     googleAnalytics({
-      trackingId: 'UA-121991291',
+      measurementIds: 'UA-121991291',
     }),
     customerIo({
       siteId: '123-xyz'
@@ -148,7 +148,7 @@ analytics.identify('user-id-xyz', {
     version: 100,
     plugins: [
       googleAnalytics({
-        trackingId: 'UA-121991291',
+        measurementIds: 'UA-121991291',
       }),
       customerIo({
         siteId: '123-xyz'
@@ -590,7 +590,7 @@ analytics.storage.removeItem('storage_key')
 
 ### analytics.plugins
 
-Async Management methods for plugins. 
+Async Management methods for plugins.
 
 This is also where [custom methods](https://bit.ly/329vFXy) are loaded into the instance.
 
@@ -901,7 +901,7 @@ const analytics = Analytics({
     // include myPlugin
     myPlugin(),
     customerIoPlugin({
-      trackingId: '1234'
+      measurementIds: '1234'
     })
     ...otherPlugins
   ]

--- a/packages/use-analytics/README.md
+++ b/packages/use-analytics/README.md
@@ -52,7 +52,7 @@ const analytics = Analytics({
   app: 'awesome-app',
   plugins: [
     googleAnalytics({
-      trackingId: 'UA-1234567',
+      measurementIds: 'UA-1234567',
     })
   ]
 })
@@ -128,7 +128,7 @@ const analytics = Analytics({
   app: 'awesome-app',
   plugins: [
     googleAnalytics({
-      trackingId: 'UA-1234567',
+      measurementIds: 'UA-1234567',
     })
   ]
 })
@@ -213,7 +213,7 @@ const analytics = Analytics({
   app: 'awesome-app',
   plugins: [
     googleAnalytics({
-      trackingId: 'UA-1234567',
+      measurementIds: 'UA-1234567',
     })
   ]
 })
@@ -272,7 +272,7 @@ const analytics = Analytics({
   app: 'awesome-app',
   plugins: [
     googleAnalytics({
-      trackingId: 'UA-1234567',
+      measurementIds: 'UA-1234567',
     })
   ]
 })

--- a/site/gatsby-theme-oss-docs/src/analytics.js
+++ b/site/gatsby-theme-oss-docs/src/analytics.js
@@ -6,7 +6,7 @@ const analytics = Analytics({
   debug: true,
   plugins: [
     googleAnalytics({
-      trackingId: 'UA-126647663-4'
+      measurementIds: 'UA-126647663-4'
     })
   ]
 })

--- a/site/main/source/conditional-loading.md
+++ b/site/main/source/conditional-loading.md
@@ -31,8 +31,8 @@ const analytics = Analytics({
   app: 'awesome-app',
   plugins: [
     googleAnalytics({
-      trackingId: 'ua-111-22222',
-      // Disable GA from loading 
+      measurementIds: 'ua-111-22222',
+      // Disable GA from loading
       enabled: false,
     }),
   ]
@@ -70,7 +70,7 @@ const analytics = Analytics({
   app: 'awesome-app',
   plugins: [
     googleAnalytics({
-      trackingId: 'ua-111-22222',
+      measurementIds: 'ua-111-22222',
       enabled: !dontTrack
     })
   ]
@@ -89,8 +89,8 @@ const analytics = Analytics({
   app: 'awesome-app',
   plugins: [
     googleAnalyticsPlugin({
-      trackingId: 'UA-xyz-123',
-      // Disable GA from loading until `analytics.plugins.enable` called 
+      measurementIds: 'UA-xyz-123',
+      // Disable GA from loading until `analytics.plugins.enable` called
       enabled: false,
     }),
     hubSpotPlugin({
@@ -167,7 +167,7 @@ const devOnlyPlugins = [
 // prod only plugins
 const prodOnlyPlugins = [
   googleAnalyticsPlugin({
-    trackingId: GOOGLE_ANALYTICS
+    measurementIds: GOOGLE_ANALYTICS
   }),
 ]
 
@@ -192,6 +192,6 @@ const analytics = Analytics({
   plugins: plugins
 })
 
-// Use it 
+// Use it
 analytics.page()
 ```

--- a/site/main/source/index.mdx
+++ b/site/main/source/index.mdx
@@ -67,7 +67,7 @@ const analytics = Analytics({
   version: 100,
   plugins: [
     googleAnalyticsPlugin({
-      trackingId: 'UA-121991291',
+      measurementIds: 'UA-121991291',
     }),
     customerIOPlugin({
       siteId: '123-xyz'

--- a/site/main/source/plugins/event-validation.md
+++ b/site/main/source/plugins/event-validation.md
@@ -110,7 +110,7 @@ const analytics = Analytics({
   plugins: [
     customValidationPlugin,
     googleAnalytics({
-      trackingId: 'UA-121991123',
+      measurementIds: 'UA-121991123',
     })
   ]
 })

--- a/site/main/source/plugins/extending-plugins.md
+++ b/site/main/source/plugins/extending-plugins.md
@@ -33,7 +33,7 @@ import googleAnalyticsPlugin from '@analytics/google-analytics'
 
 // Original google analytics plugin with no alterations
 const originalGoogleAnalytics = googleAnalytics({
-  trackingId: '1234'
+  measurementIds: '1234'
 })
 
 function myCustomTrack({ payload }) {

--- a/site/main/source/plugins/google-analytics.md
+++ b/site/main/source/plugins/google-analytics.md
@@ -256,7 +256,7 @@ const analytics = Analytics({
     }),
     /* Load Google Analytics v3 */
     googleAnalyticsV3Plugin({
-      trackingId: 'UA-11111111-2',
+      measurementIds: 'UA-11111111-2',
     }),
   ],
 })

--- a/site/main/source/plugins/perfumejs.md
+++ b/site/main/source/plugins/perfumejs.md
@@ -57,7 +57,7 @@ const analytics = Analytics({
   plugins: [
     // Attach Google analytics
     googleAnalytics({
-      trackingId: 'UA-12341131-6',
+      measurementIds: 'UA-12341131-6',
       instanceName: 'two'
     })
     // Attach Hubspot analytics
@@ -220,7 +220,7 @@ const analytics = Analytics({
   plugins: [
     // Attach Google analytics
     googleAnalytics({
-      trackingId: 'UA-12341131-6',
+      measurementIds: 'UA-12341131-6',
       instanceName: 'two'
     })
     // Attach Hubspot analytics

--- a/site/main/source/tutorials/enriching-data.md
+++ b/site/main/source/tutorials/enriching-data.md
@@ -92,7 +92,7 @@ const analytics = Analytics({
     customEnricherPlugin,
     // Attach analytic provider plugins
     googleAnalytics({
-      trackingId: '123-xyz'
+      measurementIds: '123-xyz'
     }),
     hubSpot({
       portalId: '234576'

--- a/site/main/source/tutorials/getting-started.md
+++ b/site/main/source/tutorials/getting-started.md
@@ -67,7 +67,7 @@ const analytics = Analytics({
   app: 'app-name',
   plugins: [
     googleAnalytics({
-      trackingId: 'UA-121991123',
+      measurementIds: 'UA-121991123',
     })
   ]
 })
@@ -189,7 +189,7 @@ const analytics = Analytics({
   version: 100,
   plugins: [
     googleAnalyticsPlugin({
-      trackingId: 'UA-121991291',
+      measurementIds: 'UA-121991291',
     }),
     customerIOPlugin({
       siteId: '123-xyz'
@@ -266,7 +266,7 @@ const analytics = Analytics({
   version: 100,
   plugins: [
     googleAnalyticsPlugin({
-      trackingId: 'UA-121991291',
+      measurementIds: 'UA-121991291',
     }),
     customerIOPlugin({
       siteId: '123-xyz'

--- a/site/main/source/tutorials/sending-provider-specific-events.md
+++ b/site/main/source/tutorials/sending-provider-specific-events.md
@@ -104,7 +104,7 @@ const analytics = Analytics({
   plugins: [
     // Attach analytic provider plugins
     googleAnalytics({
-      trackingId: '123-xyz'
+      measurementIds: '123-xyz'
     }),
     hubSpot({
       portalId: '234576'

--- a/site/main/source/tutorials/using-reset.md
+++ b/site/main/source/tutorials/using-reset.md
@@ -31,12 +31,12 @@ const analytics = Analytics({
   version: 100,
   plugins: [
     googleAnalyticsPlugin({
-      trackingId: 'UA-121991291',
+      measurementIds: 'UA-121991291',
     })
   ]
 })
 
-/*  
+/*
  Your app does stuff...
  User logs in to a different account...
 */

--- a/site/main/source/tutorials/using-with-react-router.md
+++ b/site/main/source/tutorials/using-with-react-router.md
@@ -29,7 +29,7 @@ const analyticsInstance = Analytics({
   plugins: [
     myPlugin,
     googleAnalytics({
-      trackingId: 'UA-XYZ-123'
+      measurementIds: 'UA-XYZ-123'
     })
   ]
 })
@@ -114,7 +114,7 @@ export default function AboutPage() {
       text: event.target.innerText
     })
   }
-  
+
   return (
     <div>
       <h1>About page</h1>

--- a/site/main/source/utils/react-hooks.md
+++ b/site/main/source/utils/react-hooks.md
@@ -51,7 +51,7 @@ const analytics = Analytics({
   app: 'awesome-app',
   plugins: [
     googleAnalytics({
-      trackingId: 'UA-1234567',
+      measurementIds: 'UA-1234567',
     })
   ]
 })
@@ -127,7 +127,7 @@ const analytics = Analytics({
   app: 'awesome-app',
   plugins: [
     googleAnalytics({
-      trackingId: 'UA-1234567',
+      measurementIds: 'UA-1234567',
     })
   ]
 })
@@ -211,7 +211,7 @@ const analytics = Analytics({
   app: 'awesome-app',
   plugins: [
     googleAnalytics({
-      trackingId: 'UA-1234567',
+      measurementIds: 'UA-1234567',
     })
   ]
 })
@@ -269,7 +269,7 @@ const analytics = Analytics({
   app: 'awesome-app',
   plugins: [
     googleAnalytics({
-      trackingId: 'UA-1234567',
+      measurementIds: 'UA-1234567',
     })
   ]
 })


### PR DESCRIPTION
Looks like the `trackingId` property in the GA plugin has been renamed to `measurementIds` but a number of the document files still reference `trackingId`. This pull updates those places