### PR TITLE
Update example doc to match GA4 IDs

### DIFF
--- a/site/main/source/plugins/google-analytics.md
+++ b/site/main/source/plugins/google-analytics.md
@@ -47,7 +47,7 @@ const analytics = Analytics({
   app: 'awesome-app',
   plugins: [
     googleAnalytics({
-      measurementIds: ['UA-1234567']
+      measurementIds: ['G-abc123']
     })
   ]
 })


### PR DESCRIPTION
- Have the example reflect GA4, with using a properly formated id for`measurementIds`.
- When trying to upgrade the library, I kept getting an error that that their wasn't a trackingId, even through I provided the measurement ID in the `G-abc123` format. It wasn't clear to me that the library was checking for `UA` vs `G` for each version when it was erroring out. 
- A note on the docs and/or a better error message when noticing the code using a `G` measurement id when using the `trackingIds` parameter. Would save a developer time.