### PR TITLE
bundle type definitions for use analytics

### DIFF
--- a/packages/use-analytics/index.d.ts
+++ b/packages/use-analytics/index.d.ts
@@ -1,0 +1,19 @@
+declare module 'use-analytics' {
+  import type { ComponentType, Context, FC, ReactNode } from 'react';
+  import type { AnalyticsInstance } from 'analytics';
+
+  export function withAnalytics<P extends object>(Component: ComponentType<P>): FC<P>;
+
+  export function useAnalytics(): AnalyticsInstance;
+  export function useTrack(): AnalyticsInstance['track'];
+  export function usePage(): AnalyticsInstance['page'];
+  export function useIdentify(): AnalyticsInstance['identify'];
+
+  export const AnalyticsConsumer: Context<AnalyticsInstance>['Consumer'];
+  export const AnalyticsContext: Context<AnalyticsInstance>;
+
+  export function AnalyticsProvider(props: {
+    instance: AnalyticsInstance;
+    children: ReactNode;
+  }): JSX.Element;
+}

--- a/packages/use-analytics/package.json
+++ b/packages/use-analytics/package.json
@@ -10,6 +10,7 @@
     "url": "git+https://github.com/DavidWells/analytics.git"
   },
   "main": "dist/index.js",
+  "types": "index.d.ts",
   "module": "dist/index.modern.js",
   "source": "src/index.js",
   "engines": {
@@ -35,7 +36,8 @@
     "babel-eslint": "^10.0.3"
   },
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "keywords": [
     "analytics",

--- a/packages/use-analytics/package.json
+++ b/packages/use-analytics/package.json
@@ -27,7 +27,8 @@
     "tiny-invariant": "^1.1.0"
   },
   "peerDependencies": {
-    "react": ">=16"
+    "react": ">=16",
+    "analytics": "^0.5.2"
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.8.3",


### PR DESCRIPTION
This might not be my personal preferred way of adding types to a package, but at least it will bring _some_ benefit to people using use-analytics.

https://github.com/DavidWells/analytics/issues/51#issuecomment-629863645

This closes #51 

I do recommend "connecting" the .js and .ts, and my suggestion is to convert `use-analytics` to TS, but this is against the wishes of the package maintainer. This is a very simple, but potentially fragile, upgrade.