### PR TITLE
fix: crash in analytics.reset for aws pinpoint

### DIFF
--- a/packages/analytics-plugin-aws-pinpoint/src/browser.js
+++ b/packages/analytics-plugin-aws-pinpoint/src/browser.js
@@ -310,7 +310,7 @@ function awsPinpointPlugin(pluginConfig = {}) {
     reset: ({ instance }) => {
       const id = instance.user('anonymousId')
       const key = getStorageKey(id)
-      storage.removeItem(key)
+      removeItem(key)
     },
     loaded: () => !!recordEvent,
   }


### PR DESCRIPTION
Title: Calling analytics.reset leads to a crash on analytics-plugin-aws-pinpoint in the browser
Browser: Chrome Version 115.0.5790.114 (Official Build) (x86_64)
OS: OSX 12.6.5



Steps to reproduce:
1. Setup a vanilla HTML in browser implementation of analytics and analytics-plugin-aws-pinpoint
2. Call analytics.reset

Result: Crash with the following stacktrace

_storage is not defined
ReferenceError: storage is not defined
    at Object.reset (https://my.bundle.min.js:2099:7)
    at https://my.bundle.min.js:2196:9319_

Analysis:
The storage object is not defined but is being used to delete a key in the reset callback of the pinpoint plugin. I have just directly used the removeItem import and I am getting results as expected. Please verify if this is the correct fix @DavidWells 