### PR TITLE
docs: update readme usage of Google Analytics plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ const analytics = Analytics({
   version: 100,
   plugins: [
     googleAnalytics({
-      trackingId: 'UA-121991291',
+      measurementIds: ['G-XXXXXXXX'],
     }),
     customerIo({
       siteId: '123-xyz'
@@ -150,7 +150,7 @@ analytics.identify('user-id-xyz', {
     version: 100,
     plugins: [
       googleAnalytics({
-        trackingId: 'UA-121991291',
+        measurementIds: ['G-XXXXXXXX'],
       }),
       customerIo({
         siteId: '123-xyz'


### PR DESCRIPTION
The package published at @analytics/google-analytics seems to be the newer GA4 package, but the usage shown was for the older UA version, so out-of-the-box usage with the sample code threw an error.

This updates the docs to use the usage as per [the package readme](https://github.com/DavidWells/analytics/tree/master/packages/analytics-plugin-google-analytics).