### PR TITLE
Fix missing comma in example code

### DIFF
--- a/site/main/source/index.mdx
+++ b/site/main/source/index.mdx
@@ -80,7 +80,7 @@ analytics.page()
 
 /* Track a custom event */
 analytics.track('userPurchase', {
-  price: 20
+  price: 20,
   item: 'pink socks'
 })
 


### PR DESCRIPTION
Which was causing an 'Unexpected token item (null)' error.