### PR TITLE
Return dispatch promise from storage, so it can get awaited

### DIFF
--- a/packages/analytics-core/src/index.js
+++ b/packages/analytics-core/src/index.js
@@ -776,7 +776,7 @@ function analytics(config = {}) {
        * analytics.storage.setItem('storage_key', 'value')
        */
       setItem: (key, value, options) => {
-        store.dispatch({
+        return store.dispatch({
           type: EVENTS.setItemStart,
           key: key,
           value: value,
@@ -794,7 +794,7 @@ function analytics(config = {}) {
        * analytics.storage.removeItem('storage_key')
        */
       removeItem: (key, options) => {
-        store.dispatch({
+        return store.dispatch({
           type: EVENTS.removeItemStart,
           key: key,
           options: options


### PR DESCRIPTION
As explained in this [issue](https://github.com/DavidWells/analytics/issues/438), the storage operations cannot get awaited. This leads to bad control flow.