### PR TITLE
loadIntegrations option to enable/disable loading of code for destinations in segment

### DIFF
--- a/packages/analytics-plugin-segment/README.md
+++ b/packages/analytics-plugin-segment/README.md
@@ -118,6 +118,7 @@ const analytics = Analytics({
 | `disableAnonymousTraffic` <br/>_optional_ - boolean| Disable loading segment for anonymous visitors |
 | `customScriptSrc` <br/>_optional_ - boolean| Override the Segment snippet url, for loading via custom CDN proxy |
 | `integrations` <br/>_optional_ - object| Enable/disable segment destinations https://bit.ly/38nRBj3 |
+| `loadIntegrations` <br/>_optional_ - object| Enable/disable loading of code for segment destinations http://bit.ly/4lWjAee |
 
 ## Server-side usage
 

--- a/packages/analytics-plugin-segment/src/browser.js
+++ b/packages/analytics-plugin-segment/src/browser.js
@@ -21,6 +21,7 @@ const config = {
  * @param {boolean} [pluginConfig.disableAnonymousTraffic] - Disable loading segment for anonymous visitors
  * @param {boolean} [pluginConfig.customScriptSrc] - Override the Segment snippet url, for loading via custom CDN proxy
  * @param {object}  [pluginConfig.integrations] - Enable/disable segment destinations https://bit.ly/38nRBj3
+ * @param {object}  [pluginConfig.loadIntegrations] - Enable/disable loading of code for segment destinations http://bit.ly/4lWjAee
  * @return {object} Analytics plugin
  * @example
  *
@@ -177,7 +178,8 @@ function initialize({ config, instance }) {
           analytics._loadOptions = e
         };
         analytics.SNIPPET_VERSION = "4.1.0";
-        analytics.load(writeKey);
+        const loadIntegrations = config.loadIntegrations && { integrations: config.loadIntegrations } || undefined;
+        analytics.load(writeKey, loadIntegrations);
       }
     }
   }();


### PR DESCRIPTION
The `integrations` config option will disable a destination that is configured in Segment, but the destination's code is still loaded. If you have a Segment destination and a plugin for this library configured for the same service, that will cause it to be loaded twice. In the case of Customer.io, this causes errors.

The `loadIntegrations` option added here allow you avoid this by disabling a Segment destination when `analytics.load` is called.

Thank you for this library and for reviewing my PR! I'm happy to integrate any feedback you may have.