### PR TITLE
Fix simple typo in index.mdx

### DIFF
--- a/site/main/source/index.mdx
+++ b/site/main/source/index.mdx
@@ -13,7 +13,7 @@ Companies frequently change analytics requirements based on evolving business ne
 
 This results in a lot of complexity, maintenance, and extra code when adding/removing analytic services to a site or application.
 
-This library aims to solves that with a simple pluggable abstraction layer.
+This library aims to solve that with a simple pluggable abstraction layer.
 
 <img src="https://user-images.githubusercontent.com/532272/68093602-42036880-fe4c-11e9-8bb9-008045da8a32.gif" />
 


### PR DESCRIPTION
Correct:

> aims to solves

to:

> aims to solve

---

👋 I came across this project from the [Jitsu docs](https://docs.jitsu.com/sending-data/npm) and noticed this small typo, so thought I'd take the opportunity to PR it.

Looking forward to learning more about the project.

Cheers!